### PR TITLE
[CDAP-2900] add app.template.dir configuration, default set to defaul…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>co.cask.cdap.distributions.release.csd</groupId>
   <artifactId>CDAP</artifactId>
-  <version>3.0.0</version>
+  <version>3.0.1</version>
   <name>The CDAP CSD for Cloudera Manager</name>
   <packaging>pom</packaging>
 

--- a/src/descriptor/service.sdl
+++ b/src/descriptor/service.sdl
@@ -2,7 +2,7 @@
   "name": "CDAP",
   "label": "Cask DAP",
   "description": "Cask Data Application Platform",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "runAs": {
     "user": "cdap",
     "group": "cdap"
@@ -119,6 +119,16 @@
       "required": true,
       "configurableInWizard": false,
       "default": "/tmp",
+      "type": "string"
+    },
+    {
+      "name": "app_template_dir",
+      "label": "App Template Dir",
+      "description": "Directory where all archives for application templates are stored",
+      "configName": "app.template.dir",
+      "required": true,
+      "configurableInWizard": false,
+      "default": "/opt/cloudera/parcels/CDAP/master/templates",
       "type": "string"
     },
     {


### PR DESCRIPTION
…t parcel location

See https://issues.cask.co/browse/CDAP-2900 for more background.  Adding ``app.template.dir`` as a regular config option, which can be modified by the user.  The default value is set to cloudera's default parcel location, and could be wrong if a user has modified it.  However, our ``cdap-default.xml`` entry will always be wrong in a CM environment.