### PR TITLE
make app.template.dir configurable in wizard

### DIFF
--- a/src/descriptor/service.sdl
+++ b/src/descriptor/service.sdl
@@ -127,7 +127,7 @@
       "description": "Directory where all archives for application templates are stored",
       "configName": "app.template.dir",
       "required": true,
-      "configurableInWizard": false,
+      "configurableInWizard": true,
       "default": "/opt/cloudera/parcels/CDAP/master/templates",
       "type": "string"
     },


### PR DESCRIPTION
- [x] add ``app.template.dir`` to the short-list of configs that show up in the "Add Service" wizard.  This is because the default value could be incorrect if the user has customized the parcel directory, and to raise awareness.  Further explanation will be added to the docs.  