### PR TITLE
Feature/app template dir in wizard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CDAP CSD CHANGELOG
 ==================
 
+v3.1.1 (Aug 5, 2015)
+- app.template.dir now configurable in wizard
+
 v3.1.0 (Jul 31, 2015)
 - Embedded remote parcel repo updated to point to CDAP 3.1.x parcels
 - Added app.template.dir configuration

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>co.cask.cdap.distributions.release.csd</groupId>
   <artifactId>CDAP</artifactId>
-  <version>3.1.0</version>
+  <version>3.1.1</version>
   <name>The CDAP CSD for Cloudera Manager</name>
   <packaging>pom</packaging>
 

--- a/src/descriptor/service.sdl
+++ b/src/descriptor/service.sdl
@@ -2,7 +2,7 @@
   "name": "CDAP",
   "label": "Cask DAP",
   "description": "Cask Data Application Platform",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "runAs": {
     "user": "cdap",
     "group": "cdap"

--- a/src/descriptor/service.sdl
+++ b/src/descriptor/service.sdl
@@ -127,7 +127,7 @@
       "description": "Directory where all archives for application templates are stored",
       "configName": "app.template.dir",
       "required": true,
-      "configurableInWizard": false,
+      "configurableInWizard": true,
       "default": "/opt/cloudera/parcels/CDAP/master/templates",
       "type": "string"
     },


### PR DESCRIPTION
- [x] cherry-picked small change from #39, to merge to release branch.  It simply makes the ``app.template.dir`` setting configurable in the initial "Add Service" wizard.  It was intended for release, and is referred to in the docs.
- [x] updated version/changelog
