### PR TITLE
CDAP-4442 set EXPLORE_ENABLED and KERBEROS_ENABLED flags to bypass in…

### DIFF
--- a/src/descriptor/service.sdl
+++ b/src/descriptor/service.sdl
@@ -98,7 +98,9 @@
       "program": "scripts/cdap-control.sh",
       "args": ["client"],
       "environmentVariables": {
-        "KAFKA_PROPERTIES" : "kafka.properties"
+        "EXPLORE_ENABLED": "${explore_enabled}",
+        "KAFKA_PROPERTIES" : "kafka.properties",
+        "KERBEROS_ENABLED": "${kerberos_auth_enabled}"
       }
     }
   },
@@ -499,7 +501,9 @@
         "program": "scripts/cdap-control.sh",
         "args": [ "router" ],
         "environmentVariables": {
+          "EXPLORE_ENABLED": "${explore_enabled}",
           "KAFKA_PROPERTIES" : "kafka.properties",
+          "KERBEROS_ENABLED": "${kerberos_auth_enabled}",
           "OPTS": "${cdap_java_opts}",
           "ROUTER_JAVA_HEAPMAX": "-Xmx${router_java_heapmax}"
         }
@@ -637,7 +641,9 @@
         "program": "scripts/cdap-control.sh",
         "args": [ "kafka-server" ],
         "environmentVariables": {
+          "EXPLORE_ENABLED": "${explore_enabled}",
           "KAFKA_PROPERTIES" : "kafka.properties",
+          "KERBEROS_ENABLED": "${kerberos_auth_enabled}",
           "OPTS": "${cdap_java_opts}",
           "KAFKA_JAVA_HEAPMAX": "-Xmx${kafka_java_heapmax}"
         }
@@ -814,7 +820,9 @@
             "program" : "scripts/cdap-control.sh",
             "args" : ["upgrade"],
             "environmentVariables": {
+              "EXPLORE_ENABLED": "${explore_enabled}",
               "KAFKA_PROPERTIES" : "kafka.properties",
+              "KERBEROS_ENABLED": "${kerberos_auth_enabled}",
               "OPTS": "${cdap_java_opts}",
               "MASTER_JAVA_HEAPMAX": "-Xmx${master_java_heapmax}"
             }
@@ -830,7 +838,9 @@
             "program" : "scripts/cdap-control.sh",
             "args" : ["postupgrade"],
             "environmentVariables": {
+              "EXPLORE_ENABLED": "${explore_enabled}",
               "KAFKA_PROPERTIES" : "kafka.properties",
+              "KERBEROS_ENABLED": "${kerberos_auth_enabled}",
               "OPTS": "${cdap_java_opts}",
               "MASTER_JAVA_HEAPMAX": "-Xmx${master_java_heapmax}"
             }
@@ -841,7 +851,9 @@
         "program": "scripts/cdap-control.sh",
         "args": [ "master" ],
         "environmentVariables": {
+          "EXPLORE_ENABLED": "${explore_enabled}",
           "KAFKA_PROPERTIES" : "kafka.properties",
+          "KERBEROS_ENABLED": "${kerberos_auth_enabled}",
           "OPTS": "${cdap_java_opts}",
           "MASTER_JAVA_HEAPMAX": "-Xmx${master_java_heapmax}"
         }
@@ -966,7 +978,9 @@
         "program": "scripts/cdap-control.sh",
         "args": [ "ui" ],
         "environmentVariables": {
-          "KAFKA_PROPERTIES" : "kafka.properties"
+          "EXPLORE_ENABLED": "${explore_enabled}",
+          "KAFKA_PROPERTIES" : "kafka.properties",
+          "KERBEROS_ENABLED": "${kerberos_auth_enabled}"
         }
       }
     },
@@ -1239,7 +1253,9 @@
         "program": "scripts/cdap-control.sh",
         "args": [ "auth-server" ],
         "environmentVariables": {
+          "EXPLORE_ENABLED": "${explore_enabled}",
           "KAFKA_PROPERTIES" : "kafka.properties",
+          "KERBEROS_ENABLED": "${kerberos_auth_enabled}",
           "OPTS": "${cdap_java_opts}",
           "AUTH_JAVA_HEAPMAX": "-Xmx${auth_java_heapmax}"
         }


### PR DESCRIPTION
…it script xmllint dependency

- [x] sets ``EXPLORE_ENABLED`` and ``KERBEROS_ENABLED`` environment variables from the CM parameters.  Avoids init scripts invoking ``cdap_get_conf`` which requires xmllint
- [x] sets these vars in all commands (for consistency)