### PR TITLE
Enable explore by default

### DIFF
--- a/src/descriptor/service.sdl
+++ b/src/descriptor/service.sdl
@@ -150,7 +150,7 @@
       "configName": "explore.enabled",
       "required": true,
       "configurableInWizard": true,
-      "default": false,
+      "default": true,
       "type": "boolean"
     },
     {


### PR DESCRIPTION
Enable explore by default in Cloudera Manager configuration.

Related PR in CDAP repo:
https://github.com/caskdata/cdap/pull/4859