### PR TITLE
create user dir for the hdfs.user property, not root.namespace

### DIFF
--- a/src/descriptor/service.sdl
+++ b/src/descriptor/service.sdl
@@ -44,7 +44,7 @@
       "label" : "Create CDAP User Dir",
       "description" : "Creates the /user/cdap HDFS directory needed for mapreduce",
       "directoryDescription" : "CDAP HDFS user directory",
-      "path" : "/user/${root_namespace}",
+      "path" : "/user/${hdfs_user}",
       "permissions" : "0755"
     }
   ],


### PR DESCRIPTION
quick bugfix.
It was creating ``hdfs:///user/cdap`` by interpolating ``/user/${root.namespace}`` instead of ``/user/${hdfs.user}``