### PR TITLE
Feature/4585 startup checks

### DIFF
--- a/src/descriptor/service.sdl
+++ b/src/descriptor/service.sdl
@@ -666,6 +666,47 @@
           "scaleFactor" : 1.3
         },
         {
+          "name": "master_startup_checks_enabled",
+          "label": "Master Startup Checks Enabled",
+          "description": "Whether checks should be run before start up to determine if the master can be correctly run. Which checks are run are determined by the master.startup.checks.packages and master.startup.checks.classes settings. If any check fails, the CDAP master will fail to start instead of waiting for the problem to be fixed. This setting only affects distributed CDAP. It does not apply to CDAP standalone.",
+          "configName": "master.startup.checks.enabled",
+          "required": true,
+          "configurableInWizard": false,
+          "default": true,
+          "type": "boolean"
+        },
+        {
+          "name": "master_startup_checks_packages",
+          "label": "Master Startup Checks Packages",
+          "description": "Comma separated list of packages containing checks that will be run before the master starts up. If any of the checks fails, the master will not start up. Checks will only be run if master.startup.checks.enabled is set to true.",
+          "configName": "master.startup.checks.packages",
+          "required": true,
+          "configurableInWizard": false,
+          "default": "co.cask.cdap.master.startup",
+          "type": "string"
+        },
+        {
+          "name": "master_startup_checks_classes",
+          "label": "Master Startup Checks Classes",
+          "description": "Comma separated list of classnames for checks that will be run before the master starts up. If any of the checks fails, the master will not start up. Checks will only be run if master.startup.checks.enabled is set to true.",
+          "configName": "master.startup.checks.classes",
+          "required": false,
+          "configurableInWizard": false,
+          "default": "",
+          "type": "string"
+        },
+        {
+          "name": "master_startup_service_timeout_seconds",
+          "label": "Master Startup Service Timeout Seconds",
+          "description": "Timeout in seconds for master services to wait for their dependent services to be available. For example, the dataset executor master service requires the transaction service, and will wait for the transaction service to become available while it is starting up. If the timeout is hit, the service will fail to start and the master will shut itself down. If set to 0 or below, master services will not wait for their dependent services to start before starting themselves.",
+          "configName": "master.startup.service.timeout.seconds",
+          "required": true,
+          "configurableInWizard": false,
+          "default": 600,
+          "type": "long",
+          "unit": "seconds"
+        },
+        {
           "name": "metadata_service_bind_address",
           "label": "Metadata Service Bind Address",
           "description": "Default inet address for binding metadata HTTP service",

--- a/src/descriptor/service.sdl
+++ b/src/descriptor/service.sdl
@@ -896,7 +896,8 @@
           "KAFKA_PROPERTIES" : "kafka.properties",
           "KERBEROS_ENABLED": "${kerberos_auth_enabled}",
           "OPTS": "${cdap_java_opts}",
-          "MASTER_JAVA_HEAPMAX": "-Xmx${master_java_heapmax}"
+          "MASTER_JAVA_HEAPMAX": "-Xmx${master_java_heapmax}",
+          "STARTUP_CHECKS_ENABLED": "${master_startup_checks_enabled}"
         }
       }
     },

--- a/src/scripts/cdap-control.sh
+++ b/src/scripts/cdap-control.sh
@@ -181,6 +181,21 @@ if [ ${MAIN_CLASS} ]; then
   echo "Using main_class: ${MAIN_CLASS}"
   echo "Using args: ${MAIN_CLASS_ARGS}"
 
+  # Run Master Startup Checks
+  if [ "${SERVICE}" == "master" ]; then
+    echo "Running startup checks -- this may take a few minutes"
+    "${JAVA}" "${JAVA_HEAPMAX}" \
+      -Dexplore.conf.files=${EXPLORE_CONF_FILES} \
+      -Dexplore.classpath=${EXPLORE_CLASSPATH} ${OPTS} \
+      -cp ${CLASSPATH} \
+      co.cask.cdap.master.startup.MasterStartupTool 2>&1
+    if [ $? -ne 0 ]; then
+      echo "Master startup checks failed. Please check the CDAP Master Role logs to address issues."
+      exit 1
+    fi
+  fi
+
+  # Exec into Master Service
   exec "${JAVA}" -Dcdap.service=${SERVICE} "${JAVA_HEAPMAX}" \
     -Dexplore.conf.files=${EXPLORE_CONF_FILES} \
     -Dexplore.classpath=${EXPLORE_CLASSPATH} "${OPTS}" \

--- a/src/scripts/cdap-control.sh
+++ b/src/scripts/cdap-control.sh
@@ -183,16 +183,18 @@ if [ ${MAIN_CLASS} ]; then
 
   # Run Master Startup Checks
   if [ "${SERVICE}" == "master" ]; then
-    echo "Running startup checks -- this may take a few minutes"
-    echo "Checks can be disabled using the master.startup.checks.enabled configuration option"
-    "${JAVA}" "${JAVA_HEAPMAX}" \
-      -Dexplore.conf.files=${EXPLORE_CONF_FILES} \
-      -Dexplore.classpath=${EXPLORE_CLASSPATH} ${OPTS} \
-      -cp ${CLASSPATH} \
-      co.cask.cdap.master.startup.MasterStartupTool 2>&1
-    if [ $? -ne 0 ]; then
-      echo "Master startup checks failed. Please check the CDAP Master Role logs to address issues."
-      exit 1
+    if [[ "${STARTUP_CHECKS_ENABLED}" == "true" ]]; then
+      echo "Running startup checks -- this may take a few minutes"
+      echo "Checks can be disabled using the master.startup.checks.enabled configuration option"
+      "${JAVA}" "${JAVA_HEAPMAX}" \
+        -Dexplore.conf.files=${EXPLORE_CONF_FILES} \
+        -Dexplore.classpath=${EXPLORE_CLASSPATH} ${OPTS} \
+        -cp ${CLASSPATH} \
+        co.cask.cdap.master.startup.MasterStartupTool 2>&1
+      if [ $? -ne 0 ]; then
+        echo "Master startup checks failed. Please check the CDAP Master Role logs to address issues."
+        exit 1
+      fi
     fi
   fi
 

--- a/src/scripts/cdap-control.sh
+++ b/src/scripts/cdap-control.sh
@@ -184,6 +184,7 @@ if [ ${MAIN_CLASS} ]; then
   # Run Master Startup Checks
   if [ "${SERVICE}" == "master" ]; then
     echo "Running startup checks -- this may take a few minutes"
+    echo "Checks can be disabled using the master.startup.checks.enabled configuration option"
     "${JAVA}" "${JAVA_HEAPMAX}" \
       -Dexplore.conf.files=${EXPLORE_CONF_FILES} \
       -Dexplore.classpath=${EXPLORE_CLASSPATH} ${OPTS} \


### PR DESCRIPTION
fixes https://issues.cask.co/browse/CDAP-4585

- [x] configurations for CDAP master startup checks.  enabled by default but not in wizard.
- [x] run startup checks if the service is master and ``STARTUP_CHECKS_ENABLED`` is true.
- [ ] potential bad user experience when using this CSD with older parcels.  The startup checks will get a classpath error.  At that point the user will need to disable the configuration and try again