### PR TITLE
CDAP-4699 add configuration for dashboard.router.check.timeout.secs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ v3.3.0 (Jan 19, 2016)
 - Bugfix in /user/cdap ownership ( Issue: #50 )
 - Ability to specify entire logback-container.xml in the safety valve ( Issues: #51 [CDAP-3360](https://issues.cask.co/browse/CDAP-3360) )
 - Enable CDAP Master Startup checks ( Issues: #52 [CDAP-4585](https://issues.cask.co/browse/CDAP-4585) )
+- Add dashboard.router.check.timeout.secs configuration to expose UI misconfiguration in CM UI ( Issues: #54 [CDAP-4699](https://issues.cask.co/browse/CDAP-4699) )
 
 v3.2.0 (Sep 22, 2015)
 ---------------------

--- a/src/descriptor/service.sdl
+++ b/src/descriptor/service.sdl
@@ -931,6 +931,17 @@
 	  "default": 9999,
 	  "type": "port"
 	},
+        {
+          "name": "dashboard_router_check_timeout_secs",
+          "label": "Dashboard Router Check Timeout Seconds",
+          "description": "Amount of time, in seconds, CDAP UI waits before exiting when not able to connect to CDAP Router on startup. Use timeout as 0 to wait indefinitely.",
+          "configName": "dashboard.router.check.timeout.secs",
+          "required": true,
+          "configurableInWizard": false,
+          "default": 60,
+          "type": "long",
+          "unit": "seconds"
+        },
 	{
 	  "name": "dashboard_ssl_bind_port",
 	  "label": "Dashboard SSL Bind Port",


### PR DESCRIPTION
fixes CDAP-4699

- [x] add ``dashboard.router.check.timeout.secs`` configuration with default value of 60 sec.  (Note, this is a different default than cdap-default.xml, and this is the first config to do that afaik.)
- [x] update changelog