### PR TITLE
Feature/4746 csd cdap home

### DIFF
--- a/src/descriptor/service.sdl
+++ b/src/descriptor/service.sdl
@@ -130,7 +130,7 @@
       "configName": "app.artifact.dir",
       "required": true,
       "configurableInWizard": true,
-      "default": "/opt/cloudera/parcels/CDAP/master/artifacts",
+      "default": "${cdap.home}/master/artifacts",
       "type": "string"
     },
     {

--- a/src/descriptor/service.sdl
+++ b/src/descriptor/service.sdl
@@ -130,8 +130,11 @@
       "configName": "app.artifact.dir",
       "required": true,
       "configurableInWizard": true,
-      "default": "${cdap.home}/master/artifacts",
-      "type": "string"
+      "type": "string_array",
+      "default": [
+        "${cdap.home}/master/artifacts"
+      ],
+      "separator": ";"
     },
     {
       "name": "enable_unrecoverable_reset",

--- a/src/scripts/cdap-control.sh
+++ b/src/scripts/cdap-control.sh
@@ -189,6 +189,7 @@ if [ ${MAIN_CLASS} ]; then
       "${JAVA}" "${JAVA_HEAPMAX}" \
         -Dexplore.conf.files=${EXPLORE_CONF_FILES} \
         -Dexplore.classpath=${EXPLORE_CLASSPATH} ${OPTS} \
+        -Dcdap.home=${CDAP_HOME} \
         -cp ${CLASSPATH} \
         co.cask.cdap.master.startup.MasterStartupTool 2>&1
       if [ $? -ne 0 ]; then
@@ -203,6 +204,7 @@ if [ ${MAIN_CLASS} ]; then
     -Dexplore.conf.files=${EXPLORE_CONF_FILES} \
     -Dexplore.classpath=${EXPLORE_CLASSPATH} "${OPTS}" \
     -Duser.dir=${LOCAL_DIR} \
+    -Dcdap.home=${CDAP_HOME} \
     -cp ${CLASSPATH} ${MAIN_CLASS} ${MAIN_CLASS_ARGS}
 
 elif [ ${MAIN_CMD} ]; then


### PR DESCRIPTION
fixes https://issues.cask.co/browse/CDAP-4746

- [x] $CDAP_HOME is already set in the parcel
- [x] pass ``-Dcdap.home=${CDAP_HOME}`` jvm flag to CDAP processes
- [x] set default app.artifact.dir to ``${cdap.home}/master/artifacts`` (to be substituted by cdap process)
- [x] change app.artifact.dir to a string_array, as it takes multiples (it really should be named app.artifact.dirs)
- [x] patched CSD installed on our internal CM server.