### PR TITLE
increase router UI timeout to 3min

### DIFF
--- a/src/descriptor/service.sdl
+++ b/src/descriptor/service.sdl
@@ -970,7 +970,7 @@
           "configName": "dashboard.router.check.timeout.secs",
           "required": true,
           "configurableInWizard": false,
-          "default": 60,
+          "default": 180,
           "type": "long",
           "unit": "seconds"
         },


### PR DESCRIPTION
increase the default ``dashboard.router.check.timeout.secs`` value from 1-min to 3-min.  I have seen a case where 1-min is too short on an automated cluster spinup/restart using the CM api.