### PR TITLE
add data.tx.timeout parameter

### DIFF
--- a/src/descriptor/service.sdl
+++ b/src/descriptor/service.sdl
@@ -190,6 +190,16 @@
       "min": 1
     },
     {
+      "name": "data_tx_timeout",
+      "label": "Transaction Client Timeout",
+      "description": "Timeout value in seconds for a transaction; if the transaction is not finished in that time, it is marked invalid",
+      "configName": "data.tx.timeout",
+      "required": true,
+      "configurableInWizard": false,
+      "default": 30,
+      "type": "long"
+    },
+    {
       "name": "dataset_executor_container_instances",
       "label": "Dataset Executor Container Instances",
       "description": "Number of dataset executor instances",


### PR DESCRIPTION
fixes https://issues.cask.co/browse/CDAP-5035.  fixing in release/3.3 and will merge to develop for 3.4.

- [x] adds ``data.tx.timeout`` as a configurable parameter in the CM UI.