### PR TITLE
remove redundant cdap kinit

### DIFF
--- a/src/scripts/cdap-control.sh
+++ b/src/scripts/cdap-control.sh
@@ -122,6 +122,9 @@ fn_exists cdap_set_classpath || cdap_set_classpath() { set_classpath ${*}; }
 fn_exists cdap_set_hive_classpath || cdap_set_hive_classpath() { set_hive_classpath ${*}; }
 fn_exists cdap_set_hbase || cdap_set_hbase() { set_hbase ${*}; }
 
+# Redefine cdap_kinit to be a no-op. CM handles kinit for us
+cdap_kinit() { return 0; }
+
 # Parse CDAP version from CDAP_HOME (exported in CDAP parcel)
 CDAP_VERSION=${VERSION:-$(basename ${CDAP_HOME} | cut -d- -f2)}
 


### PR DESCRIPTION
fixes [CDAP-5058](https://issues.cask.co/browse/CDAP-5058).  

- [x] removes the redundant kinit done by the CDAP startup scripts, by redefining the function to be a no-op.  The control script already sources a Cloudera function that performs a kinit:(https://github.com/caskdata/cm_csd/blob/develop/src/scripts/cdap-control.sh#L152).