### PR TITLE
fix logging modifiable attribute name

### DIFF
--- a/src/descriptor/service.sdl
+++ b/src/descriptor/service.sdl
@@ -719,7 +719,7 @@
       "logging": {
         "dir": "/var/log/cdap",
         "filename": "router.log",
-        "isModifiable": true,
+        "modifiable": true,
         "loggingType": "logback",
         "additionalConfigs": [
           {  
@@ -859,7 +859,7 @@
       "logging": {
         "dir": "/var/log/cdap",
         "filename": "kafka.log",
-        "isModifiable": true,
+        "modifiable": true,
         "loggingType": "logback",
         "additionalConfigs": [
           {
@@ -1101,7 +1101,7 @@
       "logging": {
         "dir": "/var/log/cdap",
         "filename": "master.log",
-        "isModifiable": true,
+        "modifiable": true,
         "loggingType": "logback",
         "additionalConfigs": [
           {
@@ -1571,7 +1571,7 @@
       "logging": {
         "dir": "/var/log/cdap",
         "filename": "auth-server.log",
-        "isModifiable": true,
+        "modifiable": true,
         "loggingType": "logback",
         "additionalConfigs": [
           {


### PR DESCRIPTION
fixes https://issues.cask.co/browse/CDAP-5620

The logback default directory ``/var/log/cdap`` is not exposed in CM as a configuration because the field name is incorrect.  this fixes that.

And note this is not caught by their sdl validator tool.

https://github.com/cloudera/cm_ext/wiki/Service-Descriptor-Language-Reference#logging