### PR TITLE
SPARK_HOME detection via cdap common init functions

### DIFF
--- a/src/scripts/cdap-control.sh
+++ b/src/scripts/cdap-control.sh
@@ -183,12 +183,16 @@ if [ ${MAIN_CLASS} ]; then
   # Include appropriate hbase_compat module in classpath
   cdap_set_hbase
 
+  # Determine SPARK_HOME
+  cdap_set_spark || echo "Could not determine SPARK_HOME! Spark support unavailable!"
+
   echo "`date` Starting Java service ${SERVICE} on `hostname`"
   "${JAVA}" -version
   echo "`ulimit -a`"
   echo "Using java_heapmax: ${JAVA_HEAPMAX}"
   echo "Using explore.conf.files: ${EXPLORE_CONF_FILES}"
   echo "Using explore.classpath: ${EXPLORE_CLASSPATH}"
+  echo "Using SPARK_HOME: ${SPARK_HOME}"
   echo "Using user.dir: ${LOCAL_DIR}"
   echo "Using classpath: ${CLASSPATH}"
   echo "Using main_class: ${MAIN_CLASS}"


### PR DESCRIPTION
calling cdap's ``cdap_set_spark`` function to dynamically set ``SPARK_HOME`` during CDAP startup on a CM cluster.

Note:
The CDH parcel includes spark libraries by default, and ``CDH_SPARK_HOME`` is always set.  I'm not using ``CDH_SPARK_HOME`` to avoid having CDAP use spark on a cluster where the user has not installed the ``Spark on Yarn`` service.  In this case, our ``cdap_set_spark`` fails due to missing client configuration only, and the following is shown in the stdout.log (which we may want to clean up):

```
ERROR - While determining Spark home, failed to get Spark settings using: spark-shell --master local
stderr:
Exception in thread "main" java.lang.NoClassDefFoundError: org/apache/hadoop/fs/FSDataInputStream
	at org.apache.spark.deploy.SparkSubmitArguments$$anonfun$mergeDefaultSparkProperties$1.apply(SparkSubmitArguments.scala:117)
	at org.apache.spark.deploy.SparkSubmitArguments$$anonfun$mergeDefaultSparkProperties$1.apply(SparkSubmitArguments.scala:117)
	at scala.Option.getOrElse(Option.scala:120)
	at org.apache.spark.deploy.SparkSubmitArguments.mergeDefaultSparkProperties(SparkSubmitArguments.scala:117)
	at org.apache.spark.deploy.SparkSubmitArguments.<init>(SparkSubmitArguments.scala:103)
	at org.apache.spark.deploy.SparkSubmit$.main(SparkSubmit.scala:113)
	at org.apache.spark.deploy.SparkSubmit.main(SparkSubmit.scala)
Caused by: java.lang.ClassNotFoundException: org.apache.hadoop.fs.FSDataInputStream
	at java.net.URLClassLoader$1.run(URLClassLoader.java:366)
	at java.net.URLClassLoader$1.run(URLClassLoader.java:355)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.net.URLClassLoader.findClass(URLClassLoader.java:354)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:425)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:308)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:358)
	... 7 more
Could not determine SPARK_HOME! Spark support unavailable!
```