### PR TITLE
Feature/5086 set spark home via svc dependency

### DIFF
--- a/src/descriptor/service.sdl
+++ b/src/descriptor/service.sdl
@@ -25,7 +25,8 @@
     {"name": "HDFS", "required": "true"},
     {"name": "YARN", "required": "true"},
     {"name": "HBASE", "required": "true"},
-    {"name": "HIVE", "required": "false"}
+    {"name": "HIVE", "required": "false"},
+    {"name": "SPARK_ON_YARN", "required": "false"}
   ],
   "rolesWithExternalLinks": [
     "CDAP_UI"

--- a/src/scripts/cdap-control.sh
+++ b/src/scripts/cdap-control.sh
@@ -183,12 +183,18 @@ if [ ${MAIN_CLASS} ]; then
   # Include appropriate hbase_compat module in classpath
   cdap_set_hbase
 
+  # If a user has selected a dependency on Spark, CM will generate spark-conf directory in CWD
+  if [ -d "spark-conf" ]; then
+    export SPARK_HOME=${CDH_SPARK_HOME}
+  fi
+
   echo "`date` Starting Java service ${SERVICE} on `hostname`"
   "${JAVA}" -version
   echo "`ulimit -a`"
   echo "Using java_heapmax: ${JAVA_HEAPMAX}"
   echo "Using explore.conf.files: ${EXPLORE_CONF_FILES}"
   echo "Using explore.classpath: ${EXPLORE_CLASSPATH}"
+  echo "Using SPARK_HOME: ${SPARK_HOME}"
   echo "Using user.dir: ${LOCAL_DIR}"
   echo "Using classpath: ${CLASSPATH}"
   echo "Using main_class: ${MAIN_CLASS}"


### PR DESCRIPTION
fixes [CDAP-5086](https://issues.cask.co/browse/CDAP-5086)
replaces https://github.com/caskdata/cm_csd/pull/75

Set ``SPARK_HOME`` by checking if the generated ``spark-conf`` directory exists (indicating service dependency), and using ``CDH_SPARK_HOME``.  There is one minor drawback with this approach worth mentioning: after initial install, it's possible to mess with service dependencies to the point where ``spark-conf`` directory exists via an implicit dependency and not a direct CDAP dependency.  See CDAP-5086 for more details.

