### PR TITLE
Feature/auth server bind address

### DIFF
--- a/src/descriptor/service.sdl
+++ b/src/descriptor/service.sdl
@@ -1427,6 +1427,16 @@
           "scaleFactor": 1.3
         },
         {
+          "name": "security_auth_server_bind_address",
+          "label": "CDAP Authentication service bind address",
+          "description": "CDAP Authentication service bind address",
+          "configName": "security.auth.server.bind.address",
+          "required": true,
+          "configurableInWizard": false,
+          "default": "0.0.0.0",
+          "type": "string"
+        },
+        {
           "name": "security_auth_server_bind_port",
           "label": "Security Auth Server Bind Port",
           "description": "CDAP Authentication service bind port",
@@ -1601,10 +1611,6 @@
               {
                 "key": "kafka.log.dir",
                 "value": "{{LOCAL_DIR}}/kafka-logs"
-              },
-              {
-                "key": "security.auth.server.address",
-                "value": "{{HOSTNAME}}"
               },
               {
                 "key": "cdap.master.kerberos.keytab",

--- a/src/scripts/cdap-control.sh
+++ b/src/scripts/cdap-control.sh
@@ -80,7 +80,7 @@ case ${SERVICE} in
     ;;
   (client)
     CLIENT_CONF_DIR=${CONF_DIR}/cdap-conf
-    HOSTNAME=`hostname`
+    HOSTNAME=`hostname -f`
     substitute_cdap_site_tokens ${CLIENT_CONF_DIR}/cdap-site.xml
     exit 0
     ;;
@@ -130,7 +130,7 @@ CDAP_VERSION=${VERSION:-$(basename ${CDAP_HOME} | cut -d- -f2)}
 
 # Token replacement in CM-generated cdap-site.xml
 # Hostname
-HOSTNAME=`hostname`
+HOSTNAME=`hostname -f`
 substitute_cdap_site_tokens ${CONF_DIR}/cdap-site.xml
 
 # Copy logback-container.xml into place unless user has populated safety valve


### PR DESCRIPTION
- [x] expose ``security.auth.server.bind.address`` to the user, instead of hardcoding it with the deprecated (and misleading) name.
- [x] use full fqdn when substituting any ``{{HOSTNAME}}`` tokens in cdap-site.xml