### PR TITLE
set JAVA_HEAPMAX for upgrade tool

### DIFF
--- a/src/scripts/cdap-control.sh
+++ b/src/scripts/cdap-control.sh
@@ -89,18 +89,24 @@ case ${SERVICE} in
     COMPONENT_HOME=${CDAP_MASTER_HOME}
     MAIN_CLASS=co.cask.cdap.data.tools.UpgradeTool
     MAIN_CLASS_ARGS="upgrade_hbase force"
+    # Set heap max, normally set in COMPONENT_CONF_SCRIPT
+    JAVA_HEAPMAX=${MASTER_JAVA_HEAPMAX:--Xmx1024m}
     ;;
   (upgrade)
     # The upgrade tool is run as master, but with an overridden $MAIN_CLASS and $MAIN_CLASS_ARGS
     COMPONENT_HOME=${CDAP_MASTER_HOME}
     MAIN_CLASS=co.cask.cdap.data.tools.UpgradeTool
     MAIN_CLASS_ARGS="upgrade force"
+    # Set heap max, normally set in COMPONENT_CONF_SCRIPT
+    JAVA_HEAPMAX=${MASTER_JAVA_HEAPMAX:--Xmx1024m}
     ;;
   (postupgrade)
     # A post-upgrade step to correct any pending flow metrics. Kafka server must be running
     COMPONENT_HOME=${CDAP_MASTER_HOME}
     MAIN_CLASS=co.cask.cdap.data.tools.flow.FlowQueuePendingCorrector
     MAIN_CLASS_ARGS=""
+    # Set heap max, normally set in COMPONENT_CONF_SCRIPT
+    JAVA_HEAPMAX=${MASTER_JAVA_HEAPMAX:--Xmx1024m}
     ;;
   (*)
     echo "Unknown service specified: ${SERVICE}"


### PR DESCRIPTION
fixes https://issues.cask.co/browse/CDAP-5891

Set java max heap for the upgrade tool commands. This will set it to whatever the Master Max Heapsize CM configuration is.

reopen of https://github.com/caskdata/cm_csd/pull/83 against the right branch