### PR TITLE
use CDAP_JAVA_OPTS instead of OPTS

### DIFF
--- a/src/descriptor/service.sdl
+++ b/src/descriptor/service.sdl
@@ -797,7 +797,7 @@
           "EXPLORE_ENABLED": "${explore_enabled}",
           "KAFKA_PROPERTIES": "kafka.properties",
           "KERBEROS_ENABLED": "${kerberos_auth_enabled}",
-          "OPTS": "${cdap_java_opts}",
+          "CDAP_JAVA_OPTS": "${cdap_java_opts}",
           "ROUTER_JAVA_HEAPMAX": "-Xmx${router_java_heapmax}"
         }
       }
@@ -937,7 +937,7 @@
           "EXPLORE_ENABLED": "${explore_enabled}",
           "KAFKA_PROPERTIES": "kafka.properties",
           "KERBEROS_ENABLED": "${kerberos_auth_enabled}",
-          "OPTS": "${cdap_java_opts}",
+          "CDAP_JAVA_OPTS": "${cdap_java_opts}",
           "KAFKA_JAVA_HEAPMAX": "-Xmx${kafka_java_heapmax}"
         }
       }
@@ -1216,7 +1216,7 @@
               "EXPLORE_ENABLED": "${explore_enabled}",
               "KAFKA_PROPERTIES": "kafka.properties",
               "KERBEROS_ENABLED": "${kerberos_auth_enabled}",
-              "OPTS": "${cdap_java_opts}",
+              "CDAP_JAVA_OPTS": "${cdap_java_opts}",
               "MASTER_JAVA_HEAPMAX": "-Xmx${master_java_heapmax}"
             }
           }
@@ -1234,7 +1234,7 @@
               "EXPLORE_ENABLED": "${explore_enabled}",
               "KAFKA_PROPERTIES" : "kafka.properties",
               "KERBEROS_ENABLED": "${kerberos_auth_enabled}",
-              "OPTS": "${cdap_java_opts}",
+              "CDAP_JAVA_OPTS": "${cdap_java_opts}",
               "MASTER_JAVA_HEAPMAX": "-Xmx${master_java_heapmax}"
             }
           }
@@ -1252,7 +1252,7 @@
               "EXPLORE_ENABLED": "${explore_enabled}",
               "KAFKA_PROPERTIES": "kafka.properties",
               "KERBEROS_ENABLED": "${kerberos_auth_enabled}",
-              "OPTS": "${cdap_java_opts}",
+              "CDAP_JAVA_OPTS": "${cdap_java_opts}",
               "MASTER_JAVA_HEAPMAX": "-Xmx${master_java_heapmax}"
             }
           }
@@ -1265,7 +1265,7 @@
           "EXPLORE_ENABLED": "${explore_enabled}",
           "KAFKA_PROPERTIES": "kafka.properties",
           "KERBEROS_ENABLED": "${kerberos_auth_enabled}",
-          "OPTS": "${cdap_java_opts}",
+          "CDAP_JAVA_OPTS": "${cdap_java_opts}",
           "MASTER_JAVA_HEAPMAX": "-Xmx${master_java_heapmax}",
           "STARTUP_CHECKS_ENABLED": "${master_startup_checks_enabled}"
         }
@@ -1685,7 +1685,7 @@
           "EXPLORE_ENABLED": "${explore_enabled}",
           "KAFKA_PROPERTIES": "kafka.properties",
           "KERBEROS_ENABLED": "${kerberos_auth_enabled}",
-          "OPTS": "${cdap_java_opts}",
+          "CDAP_JAVA_OPTS": "${cdap_java_opts}",
           "AUTH_JAVA_HEAPMAX": "-Xmx${auth_java_heapmax}"
         }
       }

--- a/src/scripts/cdap-control.sh
+++ b/src/scripts/cdap-control.sh
@@ -211,7 +211,7 @@ if [ ${MAIN_CLASS} ]; then
         echo "Checks can be disabled using the master.startup.checks.enabled configuration option"
         "${JAVA}" "${JAVA_HEAPMAX}" \
           -Dexplore.conf.files=${EXPLORE_CONF_FILES} \
-          -Dexplore.classpath=${EXPLORE_CLASSPATH} ${OPTS} \
+          -Dexplore.classpath=${EXPLORE_CLASSPATH} ${CDAP_JAVA_OPTS} \
           -Dcdap.home=${CDAP_HOME} \
           -cp ${CLASSPATH} \
           co.cask.cdap.master.startup.MasterStartupTool 2>&1
@@ -228,7 +228,7 @@ if [ ${MAIN_CLASS} ]; then
   # Exec into Master Service
   exec "${JAVA}" -Dcdap.service=${SERVICE} "${JAVA_HEAPMAX}" \
     -Dexplore.conf.files=${EXPLORE_CONF_FILES} \
-    -Dexplore.classpath=${EXPLORE_CLASSPATH} ${OPTS} \
+    -Dexplore.classpath=${EXPLORE_CLASSPATH} ${CDAP_JAVA_OPTS} \
     -Duser.dir=${LOCAL_DIR} \
     -Dcdap.home=${CDAP_HOME} \
     -cp ${CLASSPATH} ${MAIN_CLASS} ${MAIN_CLASS_ARGS}


### PR DESCRIPTION
fixes https://issues.cask.co/browse/CDAP-5956

CSD will now set the $CDAP_JAVA_OPTS env var, which the control script will include in the java invocation instead of $OPTS. This is because $OPTS is unmodifiable in CDAP's init framework. see CDAP-5956 for more details.

reopen of https://github.com/caskdata/cm_csd/pull/85 against the right branch