### PR TITLE
default java heapmax according to component-env.sh scripts, as in cda…

### DIFF
--- a/src/scripts/cdap-control.sh
+++ b/src/scripts/cdap-control.sh
@@ -152,6 +152,10 @@ if [ -n "${COMPONENT_CONF_SCRIPT}" ]; then
   source ${COMPONENT_CONF_SCRIPT}
 fi
 
+# Set JAVA_HEAPMAX from variable defined in JAVA_HEAP_VAR, unless defined already
+JAVA_HEAPMAX=${JAVA_HEAPMAX:-${!JAVA_HEAP_VAR}}
+export JAVA_HEAPMAX
+
 # CDAP_CONF is used by Web-App to find cdap-site.xml
 export CDAP_CONF=${CONF_DIR}
 


### PR DESCRIPTION
…p-6327

Mirror logic added to ``service`` script in https://github.com/caskdata/cdap/pull/5965 to set ``JAVA_HEAPMAX`` based on the variable defined in the *-env.sh scripts.

Previously, these *-env.sh scripts set ``JAVA_HEAPMAX`` from the ``MASTER_JAVA_HEAPMAX`` (or similar vars) set via the CM UI.

fixes https://issues.cask.co/browse/CDAP-6346