### PR TITLE
move hive/hbase/spark checks into master-only section, to mirror cdap…

### DIFF
--- a/src/scripts/cdap-control.sh
+++ b/src/scripts/cdap-control.sh
@@ -181,26 +181,10 @@ if [ ${MAIN_CLASS} ]; then
   # Set base classpath to include component and conf directory (CM provided)
   cdap_set_classpath ${COMPONENT_HOME} ${CONF_DIR}
 
-  # Set HIVE_HOME to CM-provided active location
-  export HIVE_HOME=${CDH_HIVE_HOME}
-  # Setup hive classpath if hive is installed, this has to be run after HBASE_CP is setup by set_classpath.
-  cdap_set_hive_classpath
-
-  # Include appropriate hbase_compat module in classpath
-  cdap_set_hbase
-
-  # If a user has selected a dependency on Spark, CM will generate spark-conf directory in CWD
-  if [ -d "spark-conf" ]; then
-    export SPARK_HOME=${CDH_SPARK_HOME}
-  fi
-
   echo "`date` Starting Java service ${SERVICE} on `hostname`"
   "${JAVA}" -version
   echo "`ulimit -a`"
   echo "Using java_heapmax: ${JAVA_HEAPMAX}"
-  echo "Using explore.conf.files: ${EXPLORE_CONF_FILES}"
-  echo "Using explore.classpath: ${EXPLORE_CLASSPATH}"
-  echo "Using SPARK_HOME: ${SPARK_HOME}"
   echo "Using user.dir: ${LOCAL_DIR}"
   echo "Using classpath: ${CLASSPATH}"
   echo "Using main_class: ${MAIN_CLASS}"
@@ -208,6 +192,24 @@ if [ ${MAIN_CLASS} ]; then
 
   # Run Master Startup Checks
   if [ "${SERVICE}" == "master" ]; then
+
+    # Set HIVE_HOME to CM-provided active location
+    export HIVE_HOME=${CDH_HIVE_HOME}
+    # Setup hive classpath if hive is installed, this has to be run after HBASE_CP is setup by set_classpath.
+    cdap_set_hive_classpath
+
+    # Include appropriate hbase_compat module in classpath
+    cdap_set_hbase
+
+    # If a user has selected a dependency on Spark, CM will generate spark-conf directory in CWD
+    if [ -d "spark-conf" ]; then
+      export SPARK_HOME=${CDH_SPARK_HOME}
+    fi
+
+    echo "Using explore.conf.files: ${EXPLORE_CONF_FILES}"
+    echo "Using explore.classpath: ${EXPLORE_CLASSPATH}"
+    echo "Using SPARK_HOME: ${SPARK_HOME}"
+
     if [[ "${STARTUP_CHECKS_ENABLED}" == "true" ]]; then
       # Run only if CDAP_VERSION >= 3.3
       __maj_version=$(echo ${CDAP_VERSION} | cut -d. -f1)


### PR DESCRIPTION
… init

Updates the CSD control script to only run the Hive, HBase, and Spark environment checks only when starting up the CDAP Master process.  This mirrors CDAP init: https://github.com/caskdata/cdap/blob/release/3.4/cdap-common/bin/service#L100-L106

Submitting as a hotfix to 3.4 branch, so we can release a 3.4.2 CSD, and will then merge to develop/3.5