### PR TITLE
expose yarn scheduler queue configs

### DIFF
--- a/src/descriptor/service.sdl
+++ b/src/descriptor/service.sdl
@@ -116,6 +116,15 @@
   "kerberos": "${kerberos_auth_enabled}",
   "parameters": [
     {
+      "name": "apps_scheduler_queue",
+      "label": "Apps Scheduler Queue",
+      "description": "Scheduler queue for CDAP programs and Explore Queries",
+      "configName": "apps.scheduler.queue",
+      "required": false,
+      "configurableInWizard": false,
+      "type": "string"
+    },
+    {
       "name": "app_temp_dir",
       "label": "App Temp Dir",
       "description": "Temp directory",
@@ -406,6 +415,15 @@
       "default": 2,
       "type": "long",
       "min": 1
+    },
+    {
+      "name": "master_services_scheduler_queue",
+      "label": "Master Services Scheduler Queue",
+      "description": "Scheduler queue for CDAP master services",
+      "configName": "master.services.scheduler.queue",
+      "required": false,
+      "configurableInWizard": false,
+      "type": "string"
     },
     {
       "name": "metrics_data_table_retention_resolution_1_seconds",


### PR DESCRIPTION
fixes [CDAP-6182](https://issues.cask.co/browse/CDAP-6182)

- [x] adds ``apps.scheduler.queue`` and ``master.services.scheduler.queue`` configurations, with no defaults... confirmed it works as expected
- [x] classified them in the "service-wide" configuration, since that's where all the other Yarn container settings are.