### PR TITLE
Feature/3 5 configs

### DIFF
--- a/src/descriptor/service.sdl
+++ b/src/descriptor/service.sdl
@@ -372,6 +372,16 @@
       "type": "boolean"
     },
     {
+      "name": "local_data_dir",
+      "label": "Local Data Directory",
+      "description": "User name for accessing HDFS",
+      "configName": "local.data.dir",
+      "required": true,
+      "configurableInWizard": true,
+      "default": "data",
+      "type": "string"
+    },
+    {
       "name": "log_saver_max_instances",
       "label": "Log Saver Max Instances",
       "description": "Maximum number of log saver instances to run in YARN",
@@ -682,6 +692,7 @@
       "configName": "security.store.file.path",
       "required": false,
       "configurableInWizard": false,
+      "default": "${local.data.dir}/store",
       "type": "string"
     },
     {

--- a/src/descriptor/service.sdl
+++ b/src/descriptor/service.sdl
@@ -688,7 +688,7 @@
     {
       "name": "security_store_file_path",
       "label": "Security Store File Path",
-      "description": "",
+      "description": "Location of the encrypted file which holds the secure store entries",
       "configName": "security.store.file.path",
       "required": false,
       "configurableInWizard": false,
@@ -698,7 +698,7 @@
     {
       "name": "security_store_provider",
       "label": "Security Store Provider",
-      "description": "",
+      "description": "Backend provider for the secure store; use 'none' if no secure store",
       "configName": "security.store.provider",
       "required": false,
       "configurableInWizard": false,

--- a/src/descriptor/service.sdl
+++ b/src/descriptor/service.sdl
@@ -706,7 +706,6 @@
       "default": "none",
       "validValues": [
         "none",
-        "file",
         "kms"
       ]
     },

--- a/src/descriptor/service.sdl
+++ b/src/descriptor/service.sdl
@@ -557,6 +557,54 @@
       "type": "port"
     },
     {
+      "name": "security_authorization_cache_enabled",
+      "label": "Security Authorization Cache Enabled",
+      "description": "Determines if authorization policies can be cached by programs; defaults to true",
+      "configName": "security.authorization.cache.enabled",
+      "required": true,
+      "configurableInWizard": false,
+      "default": true,
+      "type": "boolean"
+    },
+    {
+      "name": "security_authorization_cache_refresh_interval_secs",
+      "label": "Security Authorization Cache Refresh Interval Seconds",
+      "description": "Determines the interval in seconds after which a background thread will refresh cached authorization policies. Defaults to 50 seconds. It is recommended to keep this value slightly lower than ${security.authorization.cache.ttl.secs}, so that the cached authorization policies do not expire unless they have been explicitly revoked. This setting only takes effect if ${security.authorization.cache.enabled} is set to true.",
+      "configName": "security.authorization.cache.refresh.interval.secs",
+      "required": false,
+      "configurableInWizard": false,
+      "type": "string"
+    },
+    {
+      "name": "security_authorization_cache_ttl_secs",
+      "label": "Security Authorization Cache TTL Seconds",
+      "description": "Determines the time to live in seconds for entries in the authorization cache used by programs. Defaults to 60 seconds. This setting only takes effect if ${security.authorization.cache.enabled} is set to true.",
+      "configName": "security.authorization.cache.ttl.secs",
+      "required": true,
+      "configurableInWizard": false,
+      "default": 60,
+      "type": "long"
+    },
+    {
+      "name": "security_authorization_enabled",
+      "label": "Security Authorization Enabled",
+      "description": "When set to true, all operations in CDAP are authorized using the authorizer implementation found at the property ${security.authorization.extension.jar.path}",
+      "configName": "security.authorization.enabled",
+      "required": true,
+      "configurableInWizard": false,
+      "default": false,
+      "type": "boolean"
+    },
+    {
+      "name": "security_authorization_extension_jar_path",
+      "label": "Security Authorization Extension Jar Path",
+      "description": "If an external authorization system is used for authorizing operations on CDAP entities, this property sets the path to the bundled JAR file containing the extension code. This jar is only used when authorization is enabled by setting ${security.authorization.enabled} to true.",
+      "configName": "security.authorization.extension.jar.path",
+      "required": false,
+      "configurableInWizard": false,
+      "type": "string"
+    },
+    {
       "name": "security_enabled",
       "label": "Security Enabled",
       "description": "Determines if authentication is enabled for CDAP; if true, all requests to CDAP must provide a valid access token",
@@ -565,6 +613,49 @@
       "configurableInWizard": false,
       "default": false,
       "type": "boolean"
+    },
+    {
+      "name": "security_store_file_name",
+      "label": "Security Store File Name",
+      "description": "Name of the secure store file",
+      "configName": "security.store.file.name",
+      "required": false,
+      "configurableInWizard": false,
+      "default": "securestore",
+      "type": "string"
+    },
+    {
+      "name": "security_store_file_password",
+      "label": "Security Store File Password",
+      "description": "Password of the encrypted file which holds the secure store entries",
+      "configName": "security.store.file.password",
+      "required": false,
+      "configurableInWizard": false,
+      "type": "password"
+    },
+    {
+      "name": "security_store_file_path",
+      "label": "Security Store File Path",
+      "description": "",
+      "configName": "security.store.file.path",
+      "required": false,
+      "configurableInWizard": false,
+      "type": "string"
+    },
+    {
+      "name": "security_store_provider",
+      "label": "Security Store Provider",
+      "description": "",
+      "configName": "security.store.provider",
+      "required": false,
+      "configurableInWizard": false,
+      "type": "string_enum",
+      "default": "none",
+      "validValues": [
+        "none",
+        "file",
+        "kms"
+      ]
     },
     {
       "name": "ssl_enabled",

--- a/src/descriptor/service.sdl
+++ b/src/descriptor/service.sdl
@@ -98,7 +98,7 @@
       "peerConfigGenerators": [
         {
           "filename": "kafka.properties",
-          "params": [ "kafka_bind_port" ],
+          "params": [ "kafka_server_port" ],
           "roleName": "CDAP_KAFKA"
         }
       ]
@@ -888,7 +888,7 @@
                 "value": "{{KAFKA_SEED_BROKERS}}"
               },
               {
-                "key": "kafka.log.dir",
+                "key": "kafka.server.log.dirs",
                 "value": "{{LOCAL_DIR}}/kafka-logs"
               },
               {
@@ -905,7 +905,7 @@
         "peerConfigGenerators": [
           {
             "filename": "kafka.properties",
-            "params": [ "kafka_bind_port" ],
+            "params": [ "kafka_server_port" ],
             "roleName": "CDAP_KAFKA"
           }
         ]
@@ -986,35 +986,80 @@
           "scaleFactor": 1.3
         },
         {
-          "name": "kafka_bind_address",
-          "label": "Kafka Bind Address",
+          "name": "kafka_server_default_replication_factor",
+          "label": "Kafka Server Default Replication Factor",
+          "description": "CDAP Kafka service replication factor; used to replicate Kafka messages across multiple machines to prevent data loss in the event of a hardware failure. The recommended setting is to run at least two CDAP Kafka servers. If you are running two CDAP Kafka servers, set this value to 2; otherwise, set it to the number of CDAP Kafka servers.",
+          "configName": "kafka.server.default.replication.factor",
+          "required": true,
+          "configurableInWizard": false,
+          "default": 1,
+          "type": "long",
+          "min": 1
+        },
+        {
+          "name": "kafka_server_host_name",
+          "label": "Kafka Server Host Name",
           "description": "CDAP Kafka service bind address",
-          "configName": "kafka.bind.address",
+          "configName": "kafka.server.host.name",
           "required": true,
           "configurableInWizard": false,
           "default": "0.0.0.0",
           "type": "string"
         },
         {
-          "name": "kafka_bind_port",
-          "label": "Kafka Bind Port",
+          "name": "kafka_server_log_flush_interval_messages",
+          "label": "Kafka Server Log Flush Interval Messages",
+          "description": "The interval length at which will force an fsync of data written to the log",
+          "configName": "kafka.server.log.flush.interval.messages",
+          "required": true,
+          "configurableInWizard": false,
+          "default": 10000,
+          "type": "long",
+          "min": 1
+        },
+        {
+          "name": "kafka_server_log_retention_hours",
+          "label": "Kafka Server Log Retention Hours",
+          "description": "The number of hours to keep a log file before deleting it",
+          "configName": "kafka.server.log.retention.hours",
+          "required": true,
+          "configurableInWizard": false,
+          "default": 24,
+          "type": "long",
+          "min": 0,
+          "unit": "hours" 
+        },
+        {
+          "name": "kafka_server_num_partitions",
+          "label": "Kafka Server Number of Partitions",
+          "description": "Default number of partitions for a topic",
+          "configName": "kafka.server.num.partitions",
+          "required": true,
+          "configurableInWizard": false,
+          "default": 10,
+          "type": "long",
+          "min": 1
+        },
+        {
+          "name": "kafka_server_port",
+          "label": "Kafka Server Port",
           "description": "CDAP Kafka service bind port",
-          "configName": "kafka.bind.port",
+          "configName": "kafka.server.port",
           "required": true,
           "configurableInWizard": true,
           "default": 9092,
           "type": "port"
         },
         {
-          "name": "kafka_default_replication_factor",
-          "label": "Kafka Default Replication Factor",
-          "description": "CDAP Kafka service replication factor; used to replicate Kafka messages across multiple machines to prevent data loss in the event of a hardware failure. The recommended setting is to run at least two CDAP Kafka servers. If you are running two CDAP Kafka servers, set this value to 2; otherwise, set it to the number of CDAP Kafka servers.",
-          "configName": "kafka.default.replication.factor",
+          "name": "kafka_server_zookeeper_connection_timeout_ms",
+          "label": "Kafka Server Zookeeper Connection Timeout Milliseconds",
+          "description": "The maximum time (in milliseconds) that the client will wait to establish a connection to Zookeeper",
+          "configName": "kafka.server.zookeeper.connection.timeout.ms",
           "required": true,
           "configurableInWizard": false,
-          "default": 1,
+          "default": 1000000,
           "type": "long",
-          "min": 1
+          "unit": "milliseconds"
         },
         {
           "name": "kafka_zookeeper_namespace",
@@ -1043,7 +1088,7 @@
                 "value": "{{KAFKA_SEED_BROKERS}}"
               },
               {
-                "key": "kafka.log.dir",
+                "key": "kafka.server.log.dirs",
                 "value": "{{LOCAL_DIR}}/kafka-logs"
               }
             ]
@@ -1052,7 +1097,7 @@
         "peerConfigGenerators": [
           {
             "filename": "kafka.properties",
-            "params": [ "kafka_bind_port" ],
+            "params": [ "kafka_server_port" ],
             "roleName": "CDAP_KAFKA"
           }
         ]
@@ -1282,7 +1327,7 @@
                 "value": "{{KAFKA_SEED_BROKERS}}"
               },
               {
-                "key": "kafka.log.dir",
+                "key": "kafka.server.log.dirs",
                 "value": "{{LOCAL_DIR}}/kafka-logs"
               },
               {
@@ -1311,7 +1356,7 @@
         "peerConfigGenerators": [
           {
             "filename": "kafka.properties",
-            "params": [ "kafka_bind_port" ],
+            "params": [ "kafka_server_port" ],
             "roleName": "CDAP_KAFKA"
           }
         ],
@@ -1536,7 +1581,7 @@
                 "value": "{{KAFKA_SEED_BROKERS}}"
               },
               {
-                "key": "kafka.log.dir",
+                "key": "kafka.server.log.dirs",
                 "value": "{{LOCAL_DIR}}/kafka-logs"
               }
             ]
@@ -1545,7 +1590,7 @@
         "peerConfigGenerators": [
           {
             "filename": "kafka.properties",
-            "params": [ "kafka_bind_port" ],
+            "params": [ "kafka_server_port" ],
             "roleName": "CDAP_KAFKA"
           }
         ]
@@ -1762,7 +1807,7 @@
                 "value": "{{KAFKA_SEED_BROKERS}}"
               },
               {
-                "key": "kafka.log.dir",
+                "key": "kafka.server.log.dirs",
                 "value": "{{LOCAL_DIR}}/kafka-logs"
               },
               {
@@ -1779,7 +1824,7 @@
         "peerConfigGenerators": [
           {
             "filename": "kafka.properties",
-            "params": [ "kafka_bind_port" ],
+            "params": [ "kafka_server_port" ],
             "roleName": "CDAP_KAFKA"
           }
         ]

--- a/src/descriptor/service.sdl
+++ b/src/descriptor/service.sdl
@@ -527,6 +527,38 @@
       "min": 1
     },
     {
+      "name": "remote_system_op_exec_threads",
+      "label": "Remote System Op Exec Threads",
+      "description": "Number of Netty service executor threads for the remote system operation HTTP service",
+      "configName": "remote.system.op.exec.threads",
+      "required": false,
+      "configurableInWizard": false,
+      "default": 20,
+      "type": "long",
+      "min": 1
+    },
+    {
+      "name": "remote_system_op_service_bind_address",
+      "label": "Remote System Op Service Bind Address",
+      "description": "Remote system operation HTTP service bind address",
+      "configName": "remote.system.op.service.bind.address",
+      "required": false,
+      "configurableInWizard": false,
+      "default": "0.0.0.0",
+      "type": "string"
+    },
+    {
+      "name": "remote_system_op_worker_threads",
+      "label": "Remote System Op Worker Threads",
+      "description": "Number of Netty service IO worker threads for the remote system operation HTTP service",
+      "configName": "remote.system.op.worker.threads",
+      "required": false,
+      "configurableInWizard": false,
+      "default": 10,
+      "type": "long",
+      "min": 1
+    },
+    {
       "name": "root_namespace",
       "label": "Root Namespace",
       "description": "Root for this CDAP instance; used as the parent (or root) node for ZooKeeper, as the directory under which all CDAP data and metadata is stored in HDFS, and as the prefix for all HBase tables created by CDAP; must be composed of alphanumeric characters",

--- a/src/descriptor/service.sdl
+++ b/src/descriptor/service.sdl
@@ -667,35 +667,6 @@
       "type": "boolean"
     },
     {
-      "name": "security_store_file_name",
-      "label": "Security Store File Name",
-      "description": "Name of the secure store file",
-      "configName": "security.store.file.name",
-      "required": false,
-      "configurableInWizard": false,
-      "default": "securestore",
-      "type": "string"
-    },
-    {
-      "name": "security_store_file_password",
-      "label": "Security Store File Password",
-      "description": "Password of the encrypted file which holds the secure store entries",
-      "configName": "security.store.file.password",
-      "required": false,
-      "configurableInWizard": false,
-      "type": "password"
-    },
-    {
-      "name": "security_store_file_path",
-      "label": "Security Store File Path",
-      "description": "Location of the encrypted file which holds the secure store entries",
-      "configName": "security.store.file.path",
-      "required": false,
-      "configurableInWizard": false,
-      "default": "${local.data.dir}/store",
-      "type": "string"
-    },
-    {
       "name": "security_store_provider",
       "label": "Security Store Provider",
       "description": "Backend provider for the secure store; use 'none' if no secure store",

--- a/src/descriptor/service.sdl
+++ b/src/descriptor/service.sdl
@@ -637,6 +637,16 @@
       "type": "string"
     },
     {
+      "name": "security_authorization_system_user",
+      "label": "Security Authorization System User",
+      "description": "Determines a user for whom specific privileges are granted during CDAP startup.  This is the user used for creating the default namespace, deploying system artifacts and deploying dataset modules. This user is also granted ALL privileges on the system namespace, so it can access datasets and other entities in the system namespace. This user does not get any other privileges on user namespaces. Defaults to 'cdap'. Please set this to the user that the CDAP Master runs as in a secure, authorization-enabled environment.",
+      "configName": "security.authorization.system.user",
+      "required": false,
+      "configurableInWizard": false,
+      "default": "cdap",
+      "type": "string"
+    },
+    {
       "name": "security_enabled",
       "label": "Security Enabled",
       "description": "Determines if authentication is enabled for CDAP; if true, all requests to CDAP must provide a valid access token",


### PR DESCRIPTION
updating parameters for 3.5 release.  [CDAP-6457](https://issues.cask.co/browse/CDAP-6457)
   - [x] authorization and secure-store parameters.  filled in the description for the ``security.store.file.password``
   - [x] remote.system.op.* parameters.  set as system wide for now... probably should be master-specific, but keeping consistency with other similar settings.  Resolved the default values instead of using macros
   - [x] kafka settings
   - [x] added ``local.data.dir``, configurable in wizard, and used it as default location for ``security.store.file.password``