### PR TITLE
3.5.1 release, feature/fix upgrade classpath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CDAP CSD CHANGELOG
 ==================
 
+v3.5.1 (Aug 24, 2016)
+---------------------
+- Fixes an issue where the Upgrade Tool commands could fail ( Issues: #104 )
+
 v3.5.0 (Aug 19, 2016)
 ---------------------
 - Exposes YARN scheduler configurations ( Issues: #96 [CDAP-6182](https://issues.cask.co/browse/CDAP-6182) )

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>co.cask.cdap.distributions.release.csd</groupId>
   <artifactId>CDAP</artifactId>
-  <version>3.5.0</version>
+  <version>3.5.1</version>
   <name>The CDAP CSD for Cloudera Manager</name>
   <packaging>pom</packaging>
 

--- a/src/descriptor/service.sdl
+++ b/src/descriptor/service.sdl
@@ -2,7 +2,7 @@
   "name": "CDAP",
   "label": "CDAP",
   "description": "The Cask Data Application Platform (CDAP) is an easy-to-use, open source and enterprise-ready integrated platform for organizations to build, deploy, and operate data-driven applications.",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "runAs": {
     "user": "cdap",
     "group": "cdap"

--- a/src/scripts/cdap-control.sh
+++ b/src/scripts/cdap-control.sh
@@ -194,8 +194,8 @@ if [ ${MAIN_CLASS} ]; then
   echo "Using main_class: ${MAIN_CLASS}"
   echo "Using args: ${MAIN_CLASS_ARGS}"
 
-  # Run Master Startup Checks
-  if [ "${SERVICE}" == "master" ]; then
+  # Run Master-specific logic (for master and upgrade* services)
+  if [ ${COMPONENT_HOME} == ${CDAP_MASTER_HOME} ]; then
 
     # Set HIVE_HOME to CM-provided active location
     export HIVE_HOME=${CDH_HIVE_HOME}


### PR DESCRIPTION
- [x] fixes an issue introduced in https://github.com/caskdata/cm_csd/pull/93 where the upgradeTool commands no longer included the Hbase compat modules in the classpath
- [x] version bump for 3.5.1 release