### PR TITLE
set default UI bind port to 11011

### DIFF
--- a/src/descriptor/service.sdl
+++ b/src/descriptor/service.sdl
@@ -1520,7 +1520,7 @@
           "configName": "dashboard.bind.port",
           "required": true,
           "configurableInWizard": true,
-          "default": 9999,
+          "default": 11011,
           "type": "port"
         },
         {


### PR DESCRIPTION
update default UI port to ``11011`` with the rest of CDAP for 4.0