### PR TITLE
add queue debugger utility

### DIFF
--- a/src/descriptor/service.sdl
+++ b/src/descriptor/service.sdl
@@ -79,6 +79,14 @@
       "roleCommand": "master_post_upgrade_tasks",
       "roleName": "CDAP_MASTER",
       "runMode": "single"
+    },
+    {
+      "name": "hbase_queue_debugger_utility",
+      "label": "Run HBase Queue Debugger Utility",
+      "description": "Run the HBase Queue Debugger Utility",
+      "roleCommand": "master_hbase_queue_debugger_utility",
+      "roleName": "CDAP_MASTER",
+      "runMode": "single"
     }
   ],
   "gateway": {
@@ -1470,6 +1478,24 @@
           "commandRunner": {
             "program": "scripts/cdap-control.sh",
             "args": ["postupgrade"],
+            "environmentVariables": {
+              "EXPLORE_ENABLED": "${explore_enabled}",
+              "KAFKA_PROPERTIES": "kafka.properties",
+              "KERBEROS_ENABLED": "${kerberos_auth_enabled}",
+              "CDAP_JAVA_OPTS": "${cdap_java_opts}",
+              "MASTER_JAVA_HEAPMAX": "-Xmx${master_java_heapmax}"
+            }
+          }
+        },
+        {
+          "name": "master_hbase_queue_debugger_utility",
+          "label": "Run HBase Queue Debugger Utility",
+          "description": "Run the HBase Queue Debugger Utility",
+          "expectedExitCodes": [0],
+          "requiredRoleState": "running",
+          "commandRunner": {
+            "program": "scripts/cdap-control.sh",
+            "args": ["queuedebugger"],
             "environmentVariables": {
               "EXPLORE_ENABLED": "${explore_enabled}",
               "KAFKA_PROPERTIES": "kafka.properties",

--- a/src/descriptor/service.sdl
+++ b/src/descriptor/service.sdl
@@ -1490,7 +1490,7 @@
         {
           "name": "master_hbase_queue_debugger_utility",
           "label": "Run HBase Queue Debugger Utility",
-          "description": "Run the HBase Queue Debugger Utility",
+          "description": "Run the HBase Queue Debugger Utility. Arguments can be specified by setting CDAP_HBASE_QUEUE_DEBUGGER_ARGS in the Service Environment Safety Valve",
           "expectedExitCodes": [0],
           "requiredRoleState": "running",
           "commandRunner": {

--- a/src/scripts/cdap-control.sh
+++ b/src/scripts/cdap-control.sh
@@ -144,6 +144,9 @@ case ${SERVICE} in
     # The HBase queue debugger utility is run as master, but with an overridden $MAIN_CLASS
     COMPONENT_HOME=${CDAP_MASTER_HOME}
     MAIN_CLASS=co.cask.cdap.data.tools.HBaseQueueDebugger
+    if [[ -n ${CDAP_HBASE_QUEUE_DEBUGGER_ARGS} ]]; then
+      MAIN_CLASS_ARGS=${CDAP_HBASE_QUEUE_DEBUGGER_ARGS}
+    fi
     # Set heap max, normally set in COMPONENT_CONF_SCRIPT
     JAVA_HEAPMAX=${MASTER_JAVA_HEAPMAX:--Xmx1024m}
     ;;

--- a/src/scripts/cdap-control.sh
+++ b/src/scripts/cdap-control.sh
@@ -140,6 +140,13 @@ case ${SERVICE} in
     # Set heap max, normally set in COMPONENT_CONF_SCRIPT
     JAVA_HEAPMAX=${MASTER_JAVA_HEAPMAX:--Xmx1024m}
     ;;
+  (queuedebugger)
+    # The HBase queue debugger utility is run as master, but with an overridden $MAIN_CLASS
+    COMPONENT_HOME=${CDAP_MASTER_HOME}
+    MAIN_CLASS=co.cask.cdap.data.tools.HBaseQueueDebugger
+    # Set heap max, normally set in COMPONENT_CONF_SCRIPT
+    JAVA_HEAPMAX=${MASTER_JAVA_HEAPMAX:--Xmx1024m}
+    ;;
   (*)
     echo "Unknown service specified: ${SERVICE}"
     exit 1


### PR DESCRIPTION
fixes https://issues.cask.co/browse/CDAP-5632

adds the HBase queue debugger utility to the action menu.  See [here](https://issues.cask.co/secure/attachment/12597/Screen%20Shot%202016-12-06%20at%204.18.03%20PM.png)
