### PR TITLE
Feature/5632 generic debugger utility

### DIFF
--- a/src/descriptor/service.sdl
+++ b/src/descriptor/service.sdl
@@ -81,10 +81,10 @@
       "runMode": "single"
     },
     {
-      "name": "hbase_queue_debugger_utility",
-      "label": "Run HBase Queue Debugger Utility",
-      "description": "Run the HBase Queue Debugger Utility",
-      "roleCommand": "master_hbase_queue_debugger_utility",
+      "name": "cdap_debugger_utility",
+      "label": "Run Configured CDAP Debugger Utility",
+      "description": "Run the configured CDAP Debugger Utility. See debugger.utility.class",
+      "roleCommand": "master_debugger_utility",
       "roleName": "CDAP_MASTER",
       "runMode": "single"
     }
@@ -100,7 +100,8 @@
       "generators": [
         {
           "filename": "cdap-conf/cdap-site.xml",
-          "configFormat": "hadoop_xml"
+          "configFormat": "hadoop_xml",
+          "excludedParams": [ "cdap_java_opts", "debugger_utility_class", "debugger_utility_args" ]
         }
       ],
       "peerConfigGenerators": [
@@ -294,6 +295,28 @@
       "default": 5,
       "type": "long",
       "min": 1
+    },
+    {
+      "name": "debugger_utility_class",
+      "label": "CDAP Debugger Utility Class Name",
+      "description": "CDAP Debugger Utility Class to run from the Actions menu",
+      "required": false,
+      "configurableInWizard": false,
+      "type": "string_enum",
+      "default": "co.cask.cdap.data.tools.SimpleHBaseQueueDebugger",
+      "validValues": [
+        "co.cask.cdap.data.tools.SimpleHBaseQueueDebugger",
+        "co.cask.cdap.data.tools.HBaseQueueDebugger"
+      ]
+    },
+    {
+      "name": "debugger_utility_args",
+      "label": "CDAP Debugger Utility Arguments",
+      "description": "CDAP Debugger Utility Arguments run from the Actions menu",
+      "required": false,
+      "configurableInWizard": false,
+      "type": "string",
+      "default": "help"
     },
     {
       "name": "enable_unrecoverable_reset",
@@ -895,7 +918,7 @@
           {
             "filename": "cdap-site.xml",
             "configFormat": "hadoop_xml",
-            "excludedParams": [ "cdap_java_opts", "router_java_heapmax" ],
+            "excludedParams": [ "cdap_java_opts", "router_java_heapmax", "debugger_utility_class", "debugger_utility_args" ],
             "additionalConfigs": [
               {
                 "key": "zookeeper.quorum",
@@ -1095,7 +1118,7 @@
           {
             "filename": "cdap-site.xml",
             "configFormat": "hadoop_xml",
-            "excludedParams": [ "cdap_java_opts", "kafka_java_heapmax" ],
+            "excludedParams": [ "cdap_java_opts", "kafka_java_heapmax", "debugger_utility_class", "debugger_utility_args" ],
             "additionalConfigs": [
               {
                 "key": "zookeeper.quorum",
@@ -1334,7 +1357,7 @@
           {
             "filename": "cdap-site.xml",
             "configFormat": "hadoop_xml",
-            "excludedParams": [ "cdap_java_opts", "master_java_heapmax" ],
+            "excludedParams": [ "cdap_java_opts", "master_java_heapmax", "debugger_utility_class", "debugger_utility_args" ],
             "additionalConfigs": [
               {
                 "key": "zookeeper.quorum",
@@ -1488,20 +1511,22 @@
           }
         },
         {
-          "name": "master_hbase_queue_debugger_utility",
-          "label": "Run HBase Queue Debugger Utility",
-          "description": "Run the HBase Queue Debugger Utility. Arguments can be specified by setting CDAP_HBASE_QUEUE_DEBUGGER_ARGS in the Service Environment Safety Valve",
+          "name": "master_debugger_utility",
+          "label": "Run Configured CDAP Debugger Utility",
+          "description": "Run the configured CDAP Debugger Utility. See debugger.utility.class",
           "expectedExitCodes": [0],
           "requiredRoleState": "running",
           "commandRunner": {
             "program": "scripts/cdap-control.sh",
-            "args": ["queuedebugger"],
+            "args": ["debugger_utility"],
             "environmentVariables": {
               "EXPLORE_ENABLED": "${explore_enabled}",
               "KAFKA_PROPERTIES": "kafka.properties",
               "KERBEROS_ENABLED": "${kerberos_auth_enabled}",
               "CDAP_JAVA_OPTS": "${cdap_java_opts}",
-              "MASTER_JAVA_HEAPMAX": "-Xmx${master_java_heapmax}"
+              "MASTER_JAVA_HEAPMAX": "-Xmx${master_java_heapmax}",
+              "MAIN_CLASS": "${debugger_utility_class}",
+              "MAIN_CLASS_ARGS": "${debugger_utility_args}"
             }
           }
         }
@@ -1606,7 +1631,7 @@
           {
             "filename": "cdap-site.xml",
             "configFormat": "hadoop_xml",
-            "excludedParams": [ "cdap_java_opts" ],
+            "excludedParams": [ "cdap_java_opts", "debugger_utility_class", "debugger_utility_args" ],
             "additionalConfigs": [
               {
                 "key": "zookeeper.quorum",
@@ -1832,7 +1857,7 @@
           {
             "filename": "cdap-site.xml",
             "configFormat": "hadoop_xml",
-            "excludedParams": [ "cdap_java_opts", "auth_java_heapmax" ],
+            "excludedParams": [ "cdap_java_opts", "auth_java_heapmax", "debugger_utility_class", "debugger_utility_args" ],
             "additionalConfigs": [
               {
                 "key": "zookeeper.quorum",

--- a/src/descriptor/service.sdl
+++ b/src/descriptor/service.sdl
@@ -79,6 +79,14 @@
       "roleCommand": "master_post_upgrade_tasks",
       "roleName": "CDAP_MASTER",
       "runMode": "single"
+    },
+    {
+      "name": "hbase_queue_debugger_utility",
+      "label": "Run HBase Queue Debugger Utility",
+      "description": "Run the HBase Queue Debugger Utility",
+      "roleCommand": "master_hbase_queue_debugger_utility",
+      "roleName": "CDAP_MASTER",
+      "runMode": "single"
     }
   ],
   "gateway": {
@@ -1470,6 +1478,24 @@
           "commandRunner": {
             "program": "scripts/cdap-control.sh",
             "args": ["postupgrade"],
+            "environmentVariables": {
+              "EXPLORE_ENABLED": "${explore_enabled}",
+              "KAFKA_PROPERTIES": "kafka.properties",
+              "KERBEROS_ENABLED": "${kerberos_auth_enabled}",
+              "CDAP_JAVA_OPTS": "${cdap_java_opts}",
+              "MASTER_JAVA_HEAPMAX": "-Xmx${master_java_heapmax}"
+            }
+          }
+        },
+        {
+          "name": "master_hbase_queue_debugger_utility",
+          "label": "Run HBase Queue Debugger Utility",
+          "description": "Run the HBase Queue Debugger Utility",
+          "expectedExitCodes": [0],
+          "requiredRoleState": "running",
+          "commandRunner": {
+            "program": "scripts/cdap-control.sh",
+            "args": ["queuedebugger"],
             "environmentVariables": {
               "EXPLORE_ENABLED": "${explore_enabled}",
               "KAFKA_PROPERTIES": "kafka.properties",

--- a/src/descriptor/service.sdl
+++ b/src/descriptor/service.sdl
@@ -1490,7 +1490,7 @@
         {
           "name": "master_hbase_queue_debugger_utility",
           "label": "Run HBase Queue Debugger Utility",
-          "description": "Run the HBase Queue Debugger Utility",
+          "description": "Run the HBase Queue Debugger Utility. Arguments can be specified by setting CDAP_HBASE_QUEUE_DEBUGGER_ARGS in the Service Environment Safety Valve",
           "expectedExitCodes": [0],
           "requiredRoleState": "running",
           "commandRunner": {

--- a/src/scripts/cdap-control.sh
+++ b/src/scripts/cdap-control.sh
@@ -144,6 +144,9 @@ case ${SERVICE} in
     # The HBase queue debugger utility is run as master, but with an overridden $MAIN_CLASS
     COMPONENT_HOME=${CDAP_MASTER_HOME}
     MAIN_CLASS=co.cask.cdap.data.tools.HBaseQueueDebugger
+    if [[ -n ${CDAP_HBASE_QUEUE_DEBUGGER_ARGS} ]]; then
+      MAIN_CLASS_ARGS=${CDAP_HBASE_QUEUE_DEBUGGER_ARGS}
+    fi
     # Set heap max, normally set in COMPONENT_CONF_SCRIPT
     JAVA_HEAPMAX=${MASTER_JAVA_HEAPMAX:--Xmx1024m}
     ;;

--- a/src/scripts/cdap-control.sh
+++ b/src/scripts/cdap-control.sh
@@ -140,13 +140,11 @@ case ${SERVICE} in
     # Set heap max, normally set in COMPONENT_CONF_SCRIPT
     JAVA_HEAPMAX=${MASTER_JAVA_HEAPMAX:--Xmx1024m}
     ;;
-  (queuedebugger)
-    # The HBase queue debugger utility is run as master, but with an overridden $MAIN_CLASS
+  (debugger_utility)
+    # The debugger utility (ie HBase queue debugger) is run as master, but with an overridden $MAIN_CLASS
     COMPONENT_HOME=${CDAP_MASTER_HOME}
-    MAIN_CLASS=co.cask.cdap.data.tools.HBaseQueueDebugger
-    if [[ -n ${CDAP_HBASE_QUEUE_DEBUGGER_ARGS} ]]; then
-      MAIN_CLASS_ARGS=${CDAP_HBASE_QUEUE_DEBUGGER_ARGS}
-    fi
+    # MAIN_CLASS set by CSD, configurable by user
+    # MAIN_CLASS_ARGS set by CSD, configurable by user
     # Set heap max, normally set in COMPONENT_CONF_SCRIPT
     JAVA_HEAPMAX=${MASTER_JAVA_HEAPMAX:--Xmx1024m}
     ;;

--- a/src/scripts/cdap-control.sh
+++ b/src/scripts/cdap-control.sh
@@ -140,6 +140,13 @@ case ${SERVICE} in
     # Set heap max, normally set in COMPONENT_CONF_SCRIPT
     JAVA_HEAPMAX=${MASTER_JAVA_HEAPMAX:--Xmx1024m}
     ;;
+  (queuedebugger)
+    # The HBase queue debugger utility is run as master, but with an overridden $MAIN_CLASS
+    COMPONENT_HOME=${CDAP_MASTER_HOME}
+    MAIN_CLASS=co.cask.cdap.data.tools.HBaseQueueDebugger
+    # Set heap max, normally set in COMPONENT_CONF_SCRIPT
+    JAVA_HEAPMAX=${MASTER_JAVA_HEAPMAX:--Xmx1024m}
+    ;;
   (*)
     echo "Unknown service specified: ${SERVICE}"
     exit 1


### PR DESCRIPTION
fixes https://issues.cask.co/browse/CDAP-5632

replaces https://github.com/caskdata/cm_csd/pull/120 with a more generic solution.

- [x] adds ``debugger_utility_class`` and ``debugger_utility_args`` configurable parameters.  defaulting to "SimpleHBaseQueueDebugger" and "help"
- [x] adds "Run Configured CDAP Debugger Utility" command to the Actions menu

<img width="300" alt="screen shot 2016-12-07 at 2 12 31 am" src="https://cloud.githubusercontent.com/assets/1816517/20963591/e11eb6be-bc22-11e6-9d24-aca306bda345.png">


