### PR TITLE
add jvmBased declaration to jvm roles, and handle CSD_JAVA_OPTS 

### DIFF
--- a/src/descriptor/service.sdl
+++ b/src/descriptor/service.sdl
@@ -781,6 +781,7 @@
   "roles": [
     {
       "name": "CDAP_ROUTER",
+      "jvmBased": "true",
       "label": "CDAP Gateway/Router Service",
       "pluralLabel": "CDAP Gateway/Router Services",
       "parameters": [
@@ -981,6 +982,7 @@
     },
     {
       "name": "CDAP_KAFKA",
+      "jvmBased": "true",
       "label": "CDAP Kafka Service",
       "pluralLabel": "CDAP Kafka Services",
       "parameters": [
@@ -1166,6 +1168,7 @@
     },
     {
       "name": "CDAP_MASTER",
+      "jvmBased": "true",
       "label": "CDAP Master Service",
       "pluralLabel": "CDAP Master Services",
       "parameters": [
@@ -1617,6 +1620,7 @@
     },
     {
       "name": "CDAP_AUTH_SERVER",
+      "jvmBased": "true",
       "label": "CDAP Security Auth Service",
       "pluralLabel": "CDAP Security Auth Services",
       "topology": {

--- a/src/scripts/cdap-control.sh
+++ b/src/scripts/cdap-control.sh
@@ -221,6 +221,11 @@ if [ ${MAIN_CLASS} ]; then
   # Set base classpath to include component and conf directory (CM provided)
   cdap_set_classpath ${COMPONENT_HOME} ${CONF_DIR}
 
+  # Prepend CM-provided ${CSD_JAVA_OPTS} to our ${CDAP_JAVA_OPTS}
+  if [[ -n ${CSD_JAVA_OPTS} ]]; then
+    CDAP_JAVA_OPTS="${CSD_JAVA_OPTS} ${CDAP_JAVA_OPTS}"
+  fi
+
   echo "`date` Starting Java service ${SERVICE} on `hostname`"
   "${JAVA}" -version
   echo "`ulimit -a`"


### PR DESCRIPTION
fixes https://issues.cask.co/browse/CDAP-7555.  Adds ``jvmBased`` declaration to CSD java roles, and passes the resultant ``$CSD_JAVA_OPTS`` to the launched process.

- [x] **The 4.0 CSD will be incompatible with CM versions <5.7.**  This feature was introduced in CM 5.7
- [x] enables jstack and jmap commands for all CDAP java processes, and other benefits [here](https://github.com/cloudera/cm_ext/wiki/Service-Descriptor-Language-Reference#-jvmbased)