### PR TITLE
add more logging to help debug sourcing failures

### DIFF
--- a/src/scripts/cdap-control.sh
+++ b/src/scripts/cdap-control.sh
@@ -155,12 +155,15 @@ case ${SERVICE} in
 esac
 
 # Source Cloudera common functions (for Kerberos)
+echo "Sourcing Cloudera Common Script: ${COMMON_SCRIPT}"
 source ${COMMON_SCRIPT}
 
 # Source the CDAP common init functions
 if [[ -e ${COMPONENT_HOME}/bin/functions.sh ]]; then
+  echo "Sourcing CDAP common functions: ${COMPONENT_HOME}/bin/functions.sh"
   source ${COMPONENT_HOME}/bin/functions.sh
 else
+  echo "Sourcing CDAP pre-4.0 common functions: ${COMPONENT_HOME}/bin/common[-env].sh"
   source ${COMPONENT_HOME}/bin/common-env.sh
   source ${COMPONENT_HOME}/bin/common.sh
 fi


### PR DESCRIPTION
If the CSD control script fails when sourcing the CDAP functions.sh/common.sh, it leaves no error and is hard to debug.  Adding a few logging statements to help with any such future issues.