### PR TITLE
add cdap coprocessor setup utility

### DIFF
--- a/src/descriptor/service.sdl
+++ b/src/descriptor/service.sdl
@@ -87,6 +87,14 @@
       "roleCommand": "master_debugger_utility",
       "roleName": "CDAP_MASTER",
       "runMode": "single"
+    },
+    {
+      "name": "cdap_setup_coprocessors",
+      "label": "Run CDAP Coprocessor Setup Utility",
+      "description": "Run the CDAP Coprocessor Setup Utility",
+      "roleCommand": "master_setup_coprocessors",
+      "roleName": "CDAP_MASTER",
+      "runMode": "single"
     }
   ],
   "gateway": {
@@ -1730,6 +1738,24 @@
               "MASTER_JAVA_HEAPMAX": "-Xmx${master_java_heapmax}",
               "MAIN_CLASS": "${debugger_utility_class}",
               "MAIN_CLASS_ARGS": "${debugger_utility_args}"
+            }
+          }
+        },
+        {
+          "name": "master_setup_coprocessors",
+          "label": "Run CDAP Coprocessor Setup Utility",
+          "description": "Run the CDAP Coprocessor Setup Utility",
+          "expectedExitCodes": [0],
+          "requiredRoleState": "running",
+          "commandRunner": {
+            "program": "scripts/cdap-control.sh",
+            "args": ["setup_coprocessors"],
+            "environmentVariables": {
+              "EXPLORE_ENABLED": "${explore_enabled}",
+              "KAFKA_PROPERTIES": "kafka.properties",
+              "KERBEROS_ENABLED": "${kerberos_auth_enabled}",
+              "CDAP_JAVA_OPTS": "${cdap_java_opts}",
+              "MASTER_JAVA_HEAPMAX": "-Xmx${master_java_heapmax}"
             }
           }
         }

--- a/src/descriptor/service.sdl
+++ b/src/descriptor/service.sdl
@@ -1746,7 +1746,7 @@
           "label": "Run CDAP Coprocessor Setup Utility",
           "description": "Run the CDAP Coprocessor Setup Utility",
           "expectedExitCodes": [0],
-          "requiredRoleState": "running",
+          "requiredRoleState": "stopped",
           "commandRunner": {
             "program": "scripts/cdap-control.sh",
             "args": ["setup_coprocessors"],


### PR DESCRIPTION

- [x] runs the cdap_setup_coprocessors function on master startup (relying on its idempotency as it will re-setup the hbase environment, etc)
- [x] adds a utility Command to the actions menu to run this directly
- [ ] It's time to rewrite the control script, to leverage the new cdap init scripts, but not in this PR

![screen shot 2017-02-03 at 10 41 34 am](https://cloud.githubusercontent.com/assets/1816517/22604364/1a426aa2-ea00-11e6-8b4a-2dae83414cd2.png)

![screen_shot_2017-02-03_at_10_40_53_am](https://cloud.githubusercontent.com/assets/1816517/22606573/31cc9482-ea09-11e6-9e0e-c6e6e0bcdd9c.png)
fixes [CDAP-8227](https://issues.cask.co/browse/CDAP-8227)
