### PR TITLE
[CDAP-5453] add simple rolling restart capability

### DIFF
--- a/src/descriptor/service.sdl
+++ b/src/descriptor/service.sdl
@@ -1063,6 +1063,25 @@
       "type": "long"
     }
   ],
+  "rollingRestart": {
+    "nonWorkerSteps": [
+      {
+        "roleName": "CDAP_AUTH_SERVER"
+      },
+      {
+        "roleName": "CDAP_KAFKA"
+      },
+      {
+        "roleName": "CDAP_MASTER"
+      },
+      {
+        "roleName": "CDAP_ROUTER"
+      },
+      {
+        "roleName": "CDAP_UI"
+      }
+    ]
+  },
   "roles": [
     {
       "name": "CDAP_ROUTER",


### PR DESCRIPTION
Fixes [CDAP-5453](https://issues.cask.co/browse/CDAP-5453), adds simple rolling restart functionality.

- [x] limited to just restarting each cdap service instance, one at a time, in serial across the cluster.  See [CDAP-5453](https://issues.cask.co/browse/CDAP-5453) for more details why.