### PR TITLE
remove hbase coprocessor setup command

### DIFF
--- a/src/descriptor/service.sdl
+++ b/src/descriptor/service.sdl
@@ -87,14 +87,6 @@
       "roleCommand": "master_debugger_utility",
       "roleName": "CDAP_MASTER",
       "runMode": "single"
-    },
-    {
-      "name": "cdap_setup_coprocessors",
-      "label": "Run CDAP Coprocessor Setup Utility",
-      "description": "Run the CDAP Coprocessor Setup Utility",
-      "roleCommand": "master_setup_coprocessors",
-      "roleName": "CDAP_MASTER",
-      "runMode": "single"
     }
   ],
   "gateway": {
@@ -1757,24 +1749,6 @@
               "MASTER_JAVA_HEAPMAX": "-Xmx${master_java_heapmax}",
               "MAIN_CLASS": "${debugger_utility_class}",
               "MAIN_CLASS_ARGS": "${debugger_utility_args}"
-            }
-          }
-        },
-        {
-          "name": "master_setup_coprocessors",
-          "label": "Run CDAP Coprocessor Setup Utility",
-          "description": "Run the CDAP Coprocessor Setup Utility",
-          "expectedExitCodes": [0],
-          "requiredRoleState": "stopped",
-          "commandRunner": {
-            "program": "scripts/cdap-control.sh",
-            "args": ["setup_coprocessors"],
-            "environmentVariables": {
-              "EXPLORE_ENABLED": "${explore_enabled}",
-              "KAFKA_PROPERTIES": "kafka.properties",
-              "KERBEROS_ENABLED": "${kerberos_auth_enabled}",
-              "CDAP_JAVA_OPTS": "${cdap_java_opts}",
-              "MASTER_JAVA_HEAPMAX": "-Xmx${master_java_heapmax}"
             }
           }
         }

--- a/src/scripts/cdap-control.sh
+++ b/src/scripts/cdap-control.sh
@@ -148,14 +148,6 @@ case ${SERVICE} in
     # Set heap max, normally set in COMPONENT_CONF_SCRIPT
     JAVA_HEAPMAX=${MASTER_JAVA_HEAPMAX:--Xmx1024m}
     ;;
-  (setup_coprocessors)
-    # The coprocessor utility is run as master, but with an overridden $MAIN_CLASS
-    COMPONENT_HOME=${CDAP_MASTER_HOME}
-    MAIN_CLASS=co.cask.cdap.data.tools.CoprocessorBuildTool
-    MAIN_CLASS_ARGS=""
-    # Set heap max, normally set in COMPONENT_CONF_SCRIPT
-    JAVA_HEAPMAX=${MASTER_JAVA_HEAPMAX:--Xmx1024m}
-    ;;
   (*)
     echo "Unknown service specified: ${SERVICE}"
     exit 1


### PR DESCRIPTION
reverts most of #135, leaving only the coprocessor check on startup.

Having it as a command is redundant, and we have no way for the user to optionally specify ``force``.  Running it with ``force`` will require it be run from the cmdline, made easier now by https://github.com/caskdata/cdap/pull/8129