### PR TITLE
Feature/remove already deprecated properties

### DIFF
--- a/src/descriptor/service.sdl
+++ b/src/descriptor/service.sdl
@@ -2229,10 +2229,10 @@
           "type": "string"
         },
         {
-          "name": "notification_kafka_topic",
-          "label": "Notification Kafka Topic",
-          "description": "Kafka topic name used to publish notifications",
-          "configName": "notification.kafka.topic",
+          "name": "notification_topic",
+          "label": "Notification Topic",
+          "description": "Topic name used to publish notifications",
+          "configName": "notification.topic",
           "required": true,
           "configurableInWizard": false,
           "default": "notifications",

--- a/src/descriptor/service.sdl
+++ b/src/descriptor/service.sdl
@@ -2171,6 +2171,16 @@
           "type": "boolean"
         },
         {
+          "name": "master_services_bind_address",
+          "label": "Master Services Bind Address",
+          "description": "Bind address for app fabric service and dataset service",
+          "configName": "master.services.bind.address",
+          "required": true,
+          "configurableInWizard": false,
+          "default": "0.0.0.0",
+          "type": "string"
+        },
+        {
           "name": "master_startup_checks_enabled",
           "label": "Master Startup Checks Enabled",
           "description": "Whether checks should be run before startup to determine if the CDAP Master can be run correctly. Which checks are run is determined by the ${master.startup.checks.packages} and ${master.startup.checks.classes} settings. If any checks fail, the CDAP Master will fail to start instead of waiting for the problem to be fixed. This setting only affects Distributed CDAP.",
@@ -2249,20 +2259,12 @@
                 "value": "{{LOCAL_DIR}}/kafka-logs"
               },
               {
-                "key": "app.bind.address",
-                "value": "{{HOSTNAME}}"
-              },
-              {
                 "key": "cdap.master.kerberos.keytab",
                 "value": "{{CDAP_MASTER_KERBEROS_KEYTAB}}"
               },
               {
                 "key": "cdap.master.kerberos.principal",
                 "value": "{{CDAP_MASTER_KERBEROS_PRINCIPAL}}"
-              },
-              {
-                "key": "dataset.service.bind.address",
-                "value": "{{HOSTNAME}}"
               },
               {
                 "key": "app.adapter.dir",

--- a/src/descriptor/service.sdl
+++ b/src/descriptor/service.sdl
@@ -176,10 +176,10 @@
       "type": "boolean"
     },
     {
-      "name": "audit_kafka_topic",
-      "label": "Audit Kafka Topic",
-      "description": "Apache Kafka topic name to which audit messages are published",
-      "configName": "audit.kafka.topic",
+      "name": "audit_topic",
+      "label": "Audit Topic",
+      "description": "Topic name in the messaging system to which audit messages are published",
+      "configName": "audit.topic",
       "required": true,
       "configurableInWizard": false,
       "default": "audit",


### PR DESCRIPTION
Removes some properties that were deprecated back in 4.0:

   * ``[app,dataset.service].bind.address`` -> ``master.services.bind.address``:  no impact as ``[app,dataset.service].bind.address`` were internally generated only.
   * ``[audit,notification].kafka.topic`` -> ``[audit,notification].topic``:  some impact. if a user has customized the old values they will need to update their configuration to the new ones.  Without this change, it'll just break silently as the cdap code ignores the old names.  With this change, the CSD will at least show the diff of the configs being removed.