### PR TITLE
CDAP-8750 constrain system retry policy options

### DIFF
--- a/src/descriptor/service.sdl
+++ b/src/descriptor/service.sdl
@@ -1496,9 +1496,7 @@
       "type": "string_enum",
       "default": "fixed.delay",
       "validValues": [
-        "none",
-        "fixed.delay",
-        "exponential.backoff"
+        "fixed.delay"
       ]
     },
     {
@@ -1539,9 +1537,7 @@
       "type": "string_enum",
       "default": "fixed.delay",
       "validValues": [
-        "none",
-        "fixed.delay",
-        "exponential.backoff"
+        "fixed.delay"
       ]
     },
     {


### PR DESCRIPTION
works around https://issues.cask.co/browse/CDAP-8750, by giving only 1 option for retry.policy for system services