### PR TITLE
add optional tag & service dependencies on spark 2

### DIFF
--- a/src/descriptor/service.sdl
+++ b/src/descriptor/service.sdl
@@ -17,7 +17,8 @@
   },
   "parcel": {
     "repoUrl": "http://repository.cask.co/parcels/cdap/4.1/",
-    "requiredTags": [ "cdh", "cdap" ]
+    "requiredTags": [ "cdh", "cdap" ],
+    "optionalTags" : ["spark2"]
   },
   "icon": "images/icon.png",
   "serviceDependencies": [
@@ -26,7 +27,8 @@
     {"name": "YARN", "required": "true"},
     {"name": "HBASE", "required": "true"},
     {"name": "HIVE", "required": "false"},
-    {"name": "SPARK_ON_YARN", "required": "false"}
+    {"name": "SPARK_ON_YARN", "required": "false"},
+    {"name": "SPARK2_ON_YARN", "required": "false"}
   ],
   "rolesWithExternalLinks": [
     "CDAP_UI"


### PR DESCRIPTION
Spark 2 can be installed on CM via a separate parcel.  This adds optional dependencies to CDAP on the spark2 parcel and service.

The necessary control script updates already commited in https://github.com/caskdata/cm_csd/pull/156