### PR TITLE
version bump for 4.2.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CDAP CSD CHANGELOG
 ==================
 
+v4.2.2 (June 13, 2017)
+----------------------
+- Add cdap-env.sh to gateway role ( Issues: #168 [CDAP-11900](https://issues.cask.co/browse/CDAP-11900) )
+
 v4.2.1 (June 7, 2017)
 ---------------------
 - Update parcel repo ( Issues: #165 )

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>co.cask.cdap.distributions.release.csd</groupId>
   <artifactId>CDAP</artifactId>
-  <version>4.2.1</version>
+  <version>4.2.2</version>
   <name>The CDAP CSD for Cloudera Manager</name>
   <packaging>pom</packaging>
 

--- a/src/descriptor/service.sdl
+++ b/src/descriptor/service.sdl
@@ -2,7 +2,7 @@
   "name": "CDAP",
   "label": "CDAP",
   "description": "The Cask Data Application Platform (CDAP) is an easy-to-use, open source and enterprise-ready integrated platform for organizations to build, deploy, and operate data-driven applications.",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "runAs": {
     "user": "cdap",
     "group": "cdap"


### PR DESCRIPTION
Version bump for 4.2.2 release.  Includes:

- Add cdap-env.sh to gateway role ( Issues: #168 )
