### PR TITLE
write build version into the CSD

### DIFF
--- a/assembly.xml
+++ b/assembly.xml
@@ -20,10 +20,20 @@
         <format>jar</format>
     </formats>
     <includeBaseDirectory>false</includeBaseDirectory>
+    <files>
+      <file>
+        <source>${project.basedir}/src/scripts/build-env.sh</source>
+        <outputDirectory>/scripts</outputDirectory>
+        <filtered>true</filtered>
+      </file>
+    </files>
     <fileSets>
       <fileSet>
         <directory>${project.basedir}/src</directory>
         <outputDirectory>/</outputDirectory>
+        <excludes>
+          <exclude>build-env.sh</exclude>
+        </excludes>
         </fileSet>
      </fileSets>
 </assembly>

--- a/src/scripts/build-env.sh
+++ b/src/scripts/build-env.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# Copyright © 2017 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+export CSD_VERSION="${project.version}"

--- a/src/scripts/cdap-control.sh
+++ b/src/scripts/cdap-control.sh
@@ -56,6 +56,10 @@ function substitute_cdap_site_tokens {
   fi
 }
 
+# Source CSD build version
+[[ -e scripts/build-env.sh ]] && source scripts/build-env.sh
+echo "CSD_VERSION: ${CSD_VERSION}"
+
 # Determine relevant CDAP component paths from sourced parcel variables
 case ${SERVICE} in
   (auth-server)


### PR DESCRIPTION
first step for [CDAP-4874](https://issues.cask.co/browse/CDAP-4874):

- [x] maven update to write the build version into the CSD, so it can be subsequently compared with the CDAP parcel version

<img width="296" alt="screen shot 2017-08-02 at 10 27 43 pm" src="https://user-images.githubusercontent.com/1816517/28907365-a7cb6d82-77d2-11e7-9dd2-d1c2097da23d.png">