### PR TITLE
add optional dependency on sentry

### DIFF
--- a/src/descriptor/service.sdl
+++ b/src/descriptor/service.sdl
@@ -27,6 +27,7 @@
     {"name": "YARN", "required": "true"},
     {"name": "HBASE", "required": "true"},
     {"name": "HIVE", "required": "false"},
+    {"name": "SENTRY", "required": "false"},
     {"name": "SPARK_ON_YARN", "required": "false"},
     {"name": "SPARK2_ON_YARN", "required": "false"}
   ],


### PR DESCRIPTION
- [x] adds an optional dependency on Sentry.  If set, CDAP will receive sentry config (incl sentry-site.xml) and will be restarted whenever sentry is.