### PR TITLE
define stopRunner for master role to trigger graceful shutdown

### DIFF
--- a/src/descriptor/service.sdl
+++ b/src/descriptor/service.sdl
@@ -2550,6 +2550,9 @@
           "STARTUP_CHECKS_ENABLED": "${master_startup_checks_enabled}",
           "CSD_COMPATIBILITY_CHECK_ENABLED": "${csd_compatibility_check_enabled}"
         }
+      },
+      "stopRunner": {
+        "timeout": "300000"
       }
     },
     {


### PR DESCRIPTION
fixes https://issues.cask.co/browse/CDAP-12721

This defines a role-level [stopRunner](https://github.com/cloudera/cm_ext/wiki/Service-Descriptor-Language-Reference#stoprunner-1) for the Master role.  This adds a new "Graceful Shutdown Timeout" configuration to the master role, with a default value of 5min.

- [x] important, this raises the minimum CM version to 5.11.1, as this feature was introduced then.  We will need to update docs, etc, and will need to take this into consideration if/when backporting.