### PR TITLE
define stopRunner for master role to trigger graceful shutdown

### DIFF
--- a/src/descriptor/service.sdl
+++ b/src/descriptor/service.sdl
@@ -2693,6 +2693,9 @@
           "STARTUP_CHECKS_ENABLED": "${master_startup_checks_enabled}",
           "CSD_COMPATIBILITY_CHECK_ENABLED": "${csd_compatibility_check_enabled}"
         }
+      },
+      "stopRunner": {
+        "timeout": "300000"
       }
     },
     {


### PR DESCRIPTION
backport of https://github.com/caskdata/cm_csd/pull/181.

While this feature requires CM 5.11, I've tested on the latest CM patch versions back to 5.7 (the current documented minimum CM version to ensure the CSD is not rejected).