### PR TITLE
define stopRunner for master role to trigger graceful shutdown

### DIFF
--- a/src/descriptor/service.sdl
+++ b/src/descriptor/service.sdl
@@ -1745,6 +1745,9 @@
           "MASTER_JAVA_HEAPMAX": "-Xmx${master_java_heapmax}",
           "STARTUP_CHECKS_ENABLED": "${master_startup_checks_enabled}"
         }
+      },
+      "stopRunner": {
+        "timeout": "300000"
       }
     },
     {


### PR DESCRIPTION
backport of https://github.com/caskdata/cm_csd/pull/181.

While this feature requires CM 5.11, I've tested on the latest CM patch versions back to 5.7 (the current documented minimum CM version to ensure the CSD is not rejected).