### PR TITLE
version bump for 4.3.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 CDAP CSD CHANGELOG
 ==================
 
+v4.3.1 (Dec 5, 2017)
+--------------------
+- Add optional dependency on Sentry ( Issues: #178 )
+- Add configurable graceful shutdown timeout ( Issues: #181 #183 [CDAP-12721](https://issues.cask.co/browse/CDAP-12721) )
+
 v4.3.0 (Aug 25, 2017)
 ---------------------
 - Adds compatibility check for CDAP Parcel ( Issues: #172 #173 [CDAP-4874](https://issues.cask.co/browse/CDAP-4874) )

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>co.cask.cdap.distributions.release.csd</groupId>
   <artifactId>CDAP</artifactId>
-  <version>4.3.1-SNAPSHOT</version>
+  <version>4.3.1</version>
   <name>The CDAP CSD for Cloudera Manager</name>
   <packaging>pom</packaging>
 

--- a/src/descriptor/service.sdl
+++ b/src/descriptor/service.sdl
@@ -2,7 +2,7 @@
   "name": "CDAP",
   "label": "CDAP",
   "description": "The Cask Data Application Platform (CDAP) is an easy-to-use, open source and enterprise-ready integrated platform for organizations to build, deploy, and operate data-driven applications.",
-  "version": "4.3.1-SNAPSHOT",
+  "version": "4.3.1",
   "runAs": {
     "user": "cdap",
     "group": "cdap"


### PR DESCRIPTION
4.3.1 release.  Includes:

- Add optional dependency on Sentry ( Issues: #178 )
- Add configurable graceful shutdown timeout ( Issues: #181 #183 [CDAP-12721](https://issues.cask.co/browse/CDAP-12721) 