### PR TITLE
update jvm opts for jdk 8

### DIFF
--- a/src/descriptor/service.sdl
+++ b/src/descriptor/service.sdl
@@ -208,7 +208,7 @@
       "name": "cdap_java_opts",
       "label": "Additional Java Options",
       "description": "Additional Java Options passed on the command line",
-      "default": "-XX:+UseConcMarkSweepGC -XX:MaxPermSize=256m",
+      "default": "-XX:+UseG1GC",
       "type": "string"
     },
     {
@@ -1678,7 +1678,7 @@
       "configName": "twill.jvm.gc.opts",
       "required": true,
       "configurableInWizard": false,
-      "default": "-verbose:gc -Xloggc:<LOG_DIR>/gc.log -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=1M",
+      "default": "-XX:+UseG1GC -verbose:gc -Xloggc:<LOG_DIR>/gc.log -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=1M",
       "type": "string"
     },
     {


### PR DESCRIPTION
update JVM options consistently with https://github.com/caskdata/cdap/pull/10124

- [x] update `cdap_java_opts` as the default opts passed to each of the cdap services
- [x] update `twill.jvm.gc.opts` consistently with cdap-default.xml