### PR TITLE
CDAP-13708

### DIFF
--- a/src/descriptor/service.sdl
+++ b/src/descriptor/service.sdl
@@ -765,7 +765,7 @@
     {
       "name": "program_heartbeat_interval_seconds",
       "label": "Program Heartbeat Interval",
-      "description": "Interval of heartbeat sent from program while its running, default 30 minutes",
+      "description": "Interval of heartbeat sent from program while it's running, default 30 minutes",
       "configName": "program.heartbeat.interval.seconds",
       "configurableInWizard": false,
       "default": 1800,
@@ -774,7 +774,7 @@
     },
     {
       "name": "program_heartbeat_table_ttl_seconds",
-      "label": "Program Heartbeat table ttl",
+      "label": "Program Heartbeat table TTL",
       "description": "TTL duration for program heartbeat table, by default 30 days",
       "configName": "program.heartbeat.table.ttl.seconds",
       "configurableInWizard": false,
@@ -844,6 +844,59 @@
       "configurableInWizard": false,
       "default": "programstatusevent",
       "type": "string"
+    },
+    {
+      "name": "system_metadata_retry_policy_base_delay_ms",
+      "label": "System Metadata Retry Policy Base Delay",
+      "description": "The base delay between retries in milliseconds",
+      "configName": "system.metadata.retry.policy.base.delay.ms",
+      "configurableInWizard": false,
+      "default": 100,
+      "type": "long",
+      "unit": "milliseconds"
+    },
+    {
+      "name": "system_metadata_retry_policy_max_delay_ms",
+      "label": "System Metadata Retry Policy Max Delay",
+      "description": "The maximum delay between retries in milliseconds",
+      "configName": "system.metadata.retry.policy.max.delay.ms",
+      "configurableInWizard": false,
+      "default": 2000,
+      "type": "long",
+      "unit": "milliseconds"
+    },
+    {
+      "name": "system_metadata_retry_policy_max_retries",
+      "label": "System Metadata Retry Policy Max Retries",
+      "description": "The maximum number of retries to attempt before aborting",
+      "configName": "system.metadata.retry.policy.max.retries",
+      "configurableInWizard": false,
+      "default": 1000,
+      "type": "long"
+    },
+    {
+      "name": "system_metadata_retry_policy_max_time_secs",
+      "label": "System Metadata Retry Policy Max Time",
+      "description": "The maximum elapsed time in seconds before retries are aborted",
+      "configName": "system.metadata.retry.policy.max.time.secs",
+      "configurableInWizard": false,
+      "default": 120,
+      "type": "long",
+      "unit": "seconds"
+    },
+    {
+      "name": "system_metadata_retry_policy_type",
+      "label": "System Metadata Retry Policy type",
+      "description": "The type of retry policy for workers. Allowed options: 'none', 'fixed.delay', or 'exponential.backoff'.",
+      "configName": "system.metadata.retry.policy.type",
+      "configurableInWizard": false,
+      "default": "exponential.backoff",
+      "type": "string_enum",
+      "validValues": [
+            "none",
+            "fixed.delay",
+            "exponential.backoff"
+          ]
     },
     {
       "name": "master_services_scheduler_queue",
@@ -1684,7 +1737,7 @@
     },
     {
       "name": "system_runtime_monitor_retry_policy_max_time_secs",
-      "label": "System Runtime Monitor Retry Policy Max Time Secs",
+      "label": "System Runtime Monitor Retry Policy Max Time",
       "description": "The maximum elapsed time in seconds before retries are aborted",
       "configName": "system.runtime.monitor.retry.policy.max.time.secs",
       "configurableInWizard": false,
@@ -1741,7 +1794,7 @@
       "configName": "twill.jvm.gc.opts",
       "required": true,
       "configurableInWizard": false,
-      "default": "-XX:+UseG1GC -verbose:gc -Xloggc:&lt;LOG_DIR&gt;/gc.log -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=1M",
+      "default": "-XX:+UseG1GC -verbose:gc -Xloggc:<LOG_DIR>/gc.log -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=1M",
       "type": "string"
     },
     {
@@ -1931,7 +1984,7 @@
           "description": "Determine if access audit log is enabled",
           "configName": "router.audit.log.enabled",
           "configurableInWizard": false,
-          "default": "true",
+          "default": "false",
           "type": "boolean"
         },
         {
@@ -2308,7 +2361,7 @@
         {
           "name": "app_program_runtime_monitor_polltime_ms",
           "label": "App Program Runtime Monitor Polltime",
-          "description": "Polling time in millis to poll updates from a runtime",
+          "description": "Polling time in milliseconds to poll updates from a runtime",
           "configName": "app.program.runtime.monitor.polltime.ms",
           "configurableInWizard": false,
           "default": 2000,
@@ -2318,7 +2371,7 @@
         {
           "name": "app_program_runtime_monitor_batch_limit",
           "label": "App Program Runtime Monitor Batch Limit",
-          "description": "Number of events to fetch from a runtime in each poll call.",
+          "description": "Number of events to fetch from a runtime in each poll call",
           "configName": "app.program.runtime.monitor.batch.limit",
           "configurableInWizard": false,
           "default": 1000,
@@ -2328,11 +2381,18 @@
         {
           "name": "app_program_runtime_monitor_topics_configs",
           "label": "App Program Runtime Monitor Topics Configs",
-          "description": "A comma-separated list of topics config to be monitored by runtime monitor.",
+          "description": "A comma-separated list of topic config to be monitored by runtime monitor",
           "configName": "app.program.runtime.monitor.topics.configs",
           "configurableInWizard": false,
-          "default": "audit.topic,data.event.topic,metadata.messaging.topic,metrics.topic.prefix:${metrics.messaging.topic.num},program.status.event.topic",
-          "type": "string"
+          "default": [
+            "audit.topic",
+            "data.event.topic",
+            "metadata.messaging.topic",
+            "metrics.topic.prefix:${metrics.messaging.topic.num}",
+            "program.status.event.topic"
+          ],
+          "separator": ",",
+          "type": "string_array"
         },
         {
           "name": "app_program_runtime_monitor_graceful_shutdown_ms",
@@ -2347,11 +2407,11 @@
         {
           "name": "app_program_runtime_monitor_server_port",
           "label": "App Program Runtime Monitor Server Port",
-          "description": "CDAP Runtime monitor server bind port",
+          "description": "CDAP Runtime monitor server port",
           "configName": "app.program.runtime.monitor.server.port",
-          "configurableInWizard": false,
+          "configurableInWizard": true,
           "default": 443,
-          "type": "long",
+          "type": "port",
           "max": 65535
         },
         {
@@ -2768,59 +2828,6 @@
           "default": 0,
           "type": "long",
           "max": 65535
-        },
-        {
-          "name": "system_metadata_retry_policy_base_delay_ms",
-          "label": "System Metadata Retry Policy Base Delay",
-          "description": "The base delay between retries in milliseconds",
-          "configName": "system.metadata.retry.policy.base.delay.ms",
-          "configurableInWizard": false,
-          "default": 100,
-          "type": "long",
-          "unit": "milliseconds"
-        },
-        {
-          "name": "system_metadata_retry_policy_max_delay_ms",
-          "label": "System Metadata Retry Policy Max Delay",
-          "description": "The maximum delay between retries in milliseconds",
-          "configName": "system.metadata.retry.policy.max.delay.ms",
-          "configurableInWizard": false,
-          "default": 2000,
-          "type": "long",
-          "unit": "milliseconds"
-        },
-        {
-          "name": "system_metadata_retry_policy_max_retries",
-          "label": "System Metadata Retry Policy Max Retries",
-          "description": "The maximum number of retries to attempt before aborting",
-          "configName": "system.metadata.retry.policy.max.retries",
-          "configurableInWizard": false,
-          "default": 1000,
-          "type": "long"
-        },
-        {
-          "name": "system_metadata_retry_policy_max_time_secs",
-          "label": "System Metadata Retry Policy Max Time",
-          "description": "The maximum elapsed time in seconds before retries are aborted",
-          "configName": "system.metadata.retry.policy.max.time.secs",
-          "configurableInWizard": false,
-          "default": 120,
-          "type": "long",
-          "unit": "seconds"
-        },
-        {
-          "name": "system_metadata_retry_policy_type",
-          "label": "System Metadata Retry Policy type",
-          "description": "The type of retry policy for workers. Allowed options: 'none', 'fixed.delay', or 'exponential.backoff'.",
-          "configName": "system.metadata.retry.policy.type",
-          "configurableInWizard": false,
-          "default": "exponential.backoff",
-          "type": "string_enum",
-          "validValues": [
-                "none",
-                "fixed.delay",
-                "exponential.backoff"
-              ]
         }
       ],
       "configWriter": {

--- a/src/descriptor/service.sdl
+++ b/src/descriptor/service.sdl
@@ -159,8 +159,7 @@
       "configurableInWizard": false,
       "type": "string_array",
       "default": [
-        "${cdap.home}/master/artifacts",
-        "${cdap.home}/master/artifacts/${app.program.spark.compat}"
+        "${cdap.home}/master/artifacts"
       ],
       "separator": ";"
     },
@@ -762,6 +761,26 @@
         "fixed.delay",
         "exponential.backoff"
       ]
+    },
+    {
+      "name": "program_heartbeat_interval_seconds",
+      "label": "Program Heartbeat Interval",
+      "description": "Interval of heartbeat sent from program while its running, default 30 minutes",
+      "configName": "program.heartbeat.interval.seconds",
+      "configurableInWizard": false,
+      "default": 1800,
+      "type": "long",
+      "unit": "seconds"
+    },
+    {
+      "name": "program_heartbeat_table_ttl_seconds",
+      "label": "Program Heartbeat table ttl",
+      "description": "TTL duration for program heartbeat table, by default 30 days",
+      "configName": "program.heartbeat.table.ttl.seconds",
+      "configurableInWizard": false,
+      "default": 2592000,
+      "type": "long",
+      "unit": "seconds"
     },
     {
       "name": "program_message_retry_policy_base_delay_ms",
@@ -1544,15 +1563,6 @@
       "min": 1
     },
     {
-      "name": "stream_size_event_topic",
-      "label": "Stream Size Event Topic",
-      "description": "Topic name for publishing time events from stream size scheduler to the messaging system",
-      "configName": "stream.size.event.topic",
-      "configurableInWizard": false,
-      "default": "streamsizeevent",
-      "type": "string"
-    },
-    {
       "name": "stream_twill_java_heap_memory_ratio",
       "label": "Stream Twill Java Heap Memory Ratio",
       "description": "The minimum ratio of heap to non-heap memory for the stream service container",
@@ -1644,6 +1654,59 @@
       ]
     },
     {
+      "name": "system_runtime_monitor_retry_policy_base_delay_ms",
+      "label": "System Runtime Monitor Retry Policy Base Delay",
+      "description": "The base delay between retries in milliseconds",
+      "configName": "system.runtime.monitor.retry.policy.base.delay.ms",
+      "configurableInWizard": false,
+      "default": 100,
+      "type": "long",
+      "unit": "milliseconds"
+    },
+    {
+      "name": "system_runtime_monitor_retry_policy_max_delay_ms",
+      "label": "System Runtime Monitor Retry Policy Max Delay",
+      "description": "The maximum delay between retries in milliseconds",
+      "configName": "system.runtime.monitor.retry.policy.max.delay.ms",
+      "configurableInWizard": false,
+      "default": 1000,
+      "type": "long",
+      "unit": "milliseconds"
+    },
+    {
+      "name": "system_runtime_monitor_retry_policy_max_retries",
+      "label": "System Runtime Monitor Retry Policy Max Retries",
+      "description": "The maximum number of retries to attempt before aborting",
+      "configName": "system.runtime.monitor.retry.policy.max.retries",
+      "configurableInWizard": false,
+      "default": 2147483647,
+      "type": "long"
+    },
+    {
+      "name": "system_runtime_monitor_retry_policy_max_time_secs",
+      "label": "System Runtime Monitor Retry Policy Max Time Secs",
+      "description": "The maximum elapsed time in seconds before retries are aborted",
+      "configName": "system.runtime.monitor.retry.policy.max.time.secs",
+      "configurableInWizard": false,
+      "default": 2147483647,
+      "type": "long",
+      "unit": "seconds"
+    },
+    {
+      "name": "system_runtime_monitor_retry_policy_type",
+      "label": "System Runtime Monitor Retry Policy Type",
+      "description": "The type of retry policy for log processing. Allowed options: 'none', 'fixed.delay', or 'exponential.backoff'.",
+      "configName": "system.runtime.monitor.retry.policy.type",
+      "configurableInWizard": false,
+      "default": "exponential.backoff",
+      "type": "string_enum",
+      "validValues": [
+            "none",
+            "fixed.delay",
+            "exponential.backoff"
+          ]
+    },
+    {
       "name": "time_event_topic",
       "label": "Time Event Topic",
       "description": "Topic name for publishing time events from time scheduler to the messaging system",
@@ -1667,7 +1730,7 @@
       "description": "Desired reserved non-heap memory in megabytes for all launched Apache Twill containers. The actual value is bounded by the ${twill.java.heap.memory.ratio} setting of the container memory size. Container-specific settings also exist for CDAP system containers.",
       "configName": "twill.java.reserved.memory.mb",
       "configurableInWizard": false,
-      "default": 300,
+      "default": 768,
       "type": "memory",
       "unit": "megabytes"
     },
@@ -1678,7 +1741,7 @@
       "configName": "twill.jvm.gc.opts",
       "required": true,
       "configurableInWizard": false,
-      "default": "-XX:+UseG1GC -verbose:gc -Xloggc:<LOG_DIR>/gc.log -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=1M",
+      "default": "-XX:+UseG1GC -verbose:gc -Xloggc:&lt;LOG_DIR&gt;/gc.log -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=1M",
       "type": "string"
     },
     {
@@ -1862,6 +1925,15 @@
       "label": "CDAP Gateway/Router Service",
       "pluralLabel": "CDAP Gateway/Router Services",
       "parameters": [
+        {
+          "name": "router_audit_log_enabled",
+          "label": "Router Audit Log Enabled",
+          "description": "Determine if access audit log is enabled",
+          "configName": "router.audit.log.enabled",
+          "configurableInWizard": false,
+          "default": "true",
+          "type": "boolean"
+        },
         {
           "name": "router_bind_address",
           "label": "Router Bind Address",
@@ -2234,6 +2306,74 @@
           "type": "boolean"
         },
         {
+          "name": "app_program_runtime_monitor_polltime_ms",
+          "label": "App Program Runtime Monitor Polltime",
+          "description": "Polling time in millis to poll updates from a runtime",
+          "configName": "app.program.runtime.monitor.polltime.ms",
+          "configurableInWizard": false,
+          "default": 2000,
+          "type": "long",
+          "unit": "milliseconds"
+        },
+        {
+          "name": "app_program_runtime_monitor_batch_limit",
+          "label": "App Program Runtime Monitor Batch Limit",
+          "description": "Number of events to fetch from a runtime in each poll call.",
+          "configName": "app.program.runtime.monitor.batch.limit",
+          "configurableInWizard": false,
+          "default": 1000,
+          "type": "long",
+          "min": 1
+        },
+        {
+          "name": "app_program_runtime_monitor_topics_configs",
+          "label": "App Program Runtime Monitor Topics Configs",
+          "description": "A comma-separated list of topics config to be monitored by runtime monitor.",
+          "configName": "app.program.runtime.monitor.topics.configs",
+          "configurableInWizard": false,
+          "default": "audit.topic,data.event.topic,metadata.messaging.topic,metrics.topic.prefix:${metrics.messaging.topic.num},program.status.event.topic",
+          "type": "string"
+        },
+        {
+          "name": "app_program_runtime_monitor_graceful_shutdown_ms",
+          "label": "App Program Runtime Monitor Graceful Shutdown",
+          "description": "Number of milliseconds to wait for the runtime to shutdown after a program execution completed in that runtime.",
+          "configName": "app.program.runtime.monitor.graceful.shutdown.ms",
+          "configurableInWizard": false,
+          "default": 5000,
+          "type": "long",
+          "unit": "milliseconds"
+        },
+        {
+          "name": "app_program_runtime_monitor_server_port",
+          "label": "App Program Runtime Monitor Server Port",
+          "description": "CDAP Runtime monitor server bind port",
+          "configName": "app.program.runtime.monitor.server.port",
+          "configurableInWizard": false,
+          "default": 443,
+          "type": "long",
+          "max": 65535
+        },
+        {
+          "name": "app_program_runtime_monitor_server_consume_chunk_size",
+          "label": "App Program Runtime Monitor Server Consume Chunk Size",
+          "description": "Approximate size in bytes of each chunk streamed back to Runtime Monitor client",
+          "configName": "app.program.runtime.monitor.server.consume.chunk.size",
+          "configurableInWizard": false,
+          "default": 60000,
+          "type": "memory",
+          "unit": "bytes"
+        },
+        {
+          "name": "app_program_runtime_monitor_threads",
+          "label": "App Program Runtime Monitor Threads",
+          "description": "Maximum number of threads being used by runtime monitor for runtime monitoring",
+          "configName": "app.program.runtime.monitor.threads",
+          "configurableInWizard": false,
+          "default": 20,
+          "type": "long"
+        },
+        {
           "name": "app_program_spark_yarn_client_rewrite_enabled",
           "label": "App Program Spark Yarn Client Rewrite Enabled",
           "description": "Specify whether to rewrite the yarn.client class in Spark to work around the issue SPARK-13441 in CDH clusters",
@@ -2542,6 +2682,34 @@
           "unit": "seconds"
         },
         {
+          "name": "metadata_messaging_topic",
+          "label": "Metadata Messaging Topic",
+          "description": "Topic name used to publish metadata messages in the messaging system",
+          "configName": "metadata.messaging.topic",
+          "configurableInWizard": false,
+          "default": "metadata",
+          "type": "string"
+        },
+        {
+          "name": "metadata_messaging_fetch_size",
+          "label": "Metadata Messaging Fetch Size",
+          "description": "Number of messages to fetch from messaging system for each batch",
+          "configName": "metadata.messaging.fetch.size",
+          "configurableInWizard": false,
+          "default": 100,
+          "type": "long"
+        },
+        {
+          "name": "metadata_messaging_poll_delay_millis",
+          "label": "Metadata Messaging Poll Delay",
+          "description": "The delay in milliseconds that the lineage processor checks again for new events after it detects there was no event",
+          "configName": "metadata.messaging.poll.delay.millis",
+          "configurableInWizard": false,
+          "default": 2000,
+          "type": "long",
+          "unit": "milliseconds"
+        },
+        {
           "name": "metadata_service_bind_address",
           "label": "Metadata Service Bind Address",
           "description": "Metadata HTTP service bind address",
@@ -2562,15 +2730,6 @@
           "max": 65535
         },
         {
-          "name": "metrics_query_bind_port",
-          "label": "Metrics Query Bind Port",
-          "description": "Metrics Query service bind port",
-          "configName": "metrics.query.bind.port",
-          "configurableInWizard": false,
-          "default": 45005,
-          "type": "port"
-        },
-        {
           "name": "notification_topic",
           "label": "Notification Topic",
           "description": "Topic name used to publish notifications",
@@ -2579,6 +2738,18 @@
           "configurableInWizard": false,
           "default": "notifications",
           "type": "string"
+        },
+        {
+          "name": "runtime_extensions_dir",
+          "label": "Runtime Extensions Dir",
+          "description": "Semicolon-separated list of local directories on the CDAP Master that are scanned for program runtime extensions",
+          "configName": "runtime.extensions.dir",
+          "configurableInWizard": false,
+          "default": [
+            "/opt/cdap/master/ext/runtimeproviders"
+          ],
+          "separator": ";",
+          "type": "string_array"
         },
         {
           "name": "security_keytab_path",
@@ -2597,6 +2768,59 @@
           "default": 0,
           "type": "long",
           "max": 65535
+        },
+        {
+          "name": "system_metadata_retry_policy_base_delay_ms",
+          "label": "System Metadata Retry Policy Base Delay",
+          "description": "The base delay between retries in milliseconds",
+          "configName": "system.metadata.retry.policy.base.delay.ms",
+          "configurableInWizard": false,
+          "default": 100,
+          "type": "long",
+          "unit": "milliseconds"
+        },
+        {
+          "name": "system_metadata_retry_policy_max_delay_ms",
+          "label": "System Metadata Retry Policy Max Delay",
+          "description": "The maximum delay between retries in milliseconds",
+          "configName": "system.metadata.retry.policy.max.delay.ms",
+          "configurableInWizard": false,
+          "default": 2000,
+          "type": "long",
+          "unit": "milliseconds"
+        },
+        {
+          "name": "system_metadata_retry_policy_max_retries",
+          "label": "System Metadata Retry Policy Max Retries",
+          "description": "The maximum number of retries to attempt before aborting",
+          "configName": "system.metadata.retry.policy.max.retries",
+          "configurableInWizard": false,
+          "default": 1000,
+          "type": "long"
+        },
+        {
+          "name": "system_metadata_retry_policy_max_time_secs",
+          "label": "System Metadata Retry Policy Max Time",
+          "description": "The maximum elapsed time in seconds before retries are aborted",
+          "configName": "system.metadata.retry.policy.max.time.secs",
+          "configurableInWizard": false,
+          "default": 120,
+          "type": "long",
+          "unit": "seconds"
+        },
+        {
+          "name": "system_metadata_retry_policy_type",
+          "label": "System Metadata Retry Policy type",
+          "description": "The type of retry policy for workers. Allowed options: 'none', 'fixed.delay', or 'exponential.backoff'.",
+          "configName": "system.metadata.retry.policy.type",
+          "configurableInWizard": false,
+          "default": "exponential.backoff",
+          "type": "string_enum",
+          "validValues": [
+                "none",
+                "fixed.delay",
+                "exponential.backoff"
+              ]
         }
       ],
       "configWriter": {

--- a/src/scripts/cdap-control.sh
+++ b/src/scripts/cdap-control.sh
@@ -360,7 +360,6 @@ if [ ${MAIN_CLASS} ]; then
     -Dexplore.classpath=${EXPLORE_CLASSPATH} ${CDAP_JAVA_OPTS} \
     -Duser.dir=${LOCAL_DIR} \
     -Dcdap.home=${CDAP_HOME} \
-    -Dapp.program.spark.compat=${SPARK_COMPAT} \
     -cp ${CLASSPATH} ${MAIN_CLASS} ${MAIN_CLASS_ARGS}
 
 elif [ ${MAIN_CMD} ]; then


### PR DESCRIPTION
This is the config update for 5.0.
https://issues.cask.co/browse/CDAP-13708

The default value for `router_audit_log_enabled` was set to `${security.enabled}` but the build failed with 
`Can not construct instance of java.lang.Boolean from String value 'boolean': only "true" or "false" recognized`
I defaulted to true, but we should consider changing this to a string. 