### PR TITLE
version bump for 5.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 CDAP CSD CHANGELOG
 ==================
 
+v5.0.0 (Jul 30, 2018)
+---------------------
+- Update default configurations for better usability ( Issues: #187 [CDAP-12767](https://issues.cask.co/browse/CDAP-12767) )
+- Update default JVM options for JDK 8 ( Issues: #191 )
+- Update default twill JVM options for JDK 8 ( Issues: #192 [CDAP-13416](https://issues.cask.co/browse/CDAP-13416) )
+- Add configurations for CDAP 5.0 release ( Issues: #193 #194 #195 [CDAP-13708](https://issues.cask.co/browse/CDAP-13708) )
+
 v4.3.1 (Dec 5, 2017)
 --------------------
 - Add optional dependency on Sentry ( Issues: #178 )

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>co.cask.cdap.distributions.release.csd</groupId>
   <artifactId>CDAP</artifactId>
-  <version>5.0.0-SNAPSHOT</version>
+  <version>5.0.0</version>
   <name>The CDAP CSD for Cloudera Manager</name>
   <packaging>pom</packaging>
 

--- a/src/descriptor/service.sdl
+++ b/src/descriptor/service.sdl
@@ -2,7 +2,7 @@
   "name": "CDAP",
   "label": "CDAP",
   "description": "The Cask Data Application Platform (CDAP) is an easy-to-use, open source and enterprise-ready integrated platform for organizations to build, deploy, and operate data-driven applications.",
-  "version": "5.0.0-SNAPSHOT",
+  "version": "5.0.0",
   "runAs": {
     "user": "cdap",
     "group": "cdap"


### PR DESCRIPTION
- Update default configurations for better usability ( Issues: #187 [CDAP-12767](https://issues.cask.co/browse/CDAP-12767) )
- Update default JVM options for JDK 8 ( Issues: #191 )
- Update default twill JVM options for JDK 8 ( Issues: #192 [CDAP-13416](https://issues.cask.co/browse/CDAP-13416) )
- Add configurations for CDAP 5.0 release ( Issues: #193 #194 #195 [CDAP-13708](https://issues.cask.co/browse/CDAP-13708) )
