### PR TITLE
specify full path in exclude

### DIFF
--- a/assembly.xml
+++ b/assembly.xml
@@ -32,7 +32,7 @@
         <directory>${project.basedir}/src</directory>
         <outputDirectory>/</outputDirectory>
         <excludes>
-          <exclude>build-env.sh</exclude>
+          <exclude>scripts/build-env.sh</exclude>
         </excludes>
         </fileSet>
      </fileSets>


### PR DESCRIPTION
specify full path on exclude directive.  empirically this appears to prevent having the unsubstituted token in the built CSD jar